### PR TITLE
feat: add add-on skeleton with HA test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build CI image
         run: docker build -f Dockerfile.ci .
       - name: Build add-on image
-        run: docker build addons/ha-llm-ops
+        run: docker build -f addons/ha-llm-ops/Dockerfile .
 
   docs:
     runs-on: ubuntu-latest

--- a/addons/ha-llm-ops/Dockerfile
+++ b/addons/ha-llm-ops/Dockerfile
@@ -1,2 +1,14 @@
-FROM alpine:3.19.1
-CMD ["/bin/sh", "-c", "echo Hello from HA LLM Ops add-on"]
+FROM python:3.11-alpine
+
+WORKDIR /app
+RUN apk add --no-cache jq
+
+COPY agent /app/agent
+COPY addons/ha-llm-ops/run.sh /run.sh
+COPY pyproject.toml /app/
+
+RUN pip install --no-cache-dir /app
+
+HEALTHCHECK CMD pgrep -f agent.main >/dev/null || exit 1
+
+CMD ["/run.sh"]

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -7,5 +7,11 @@ arch:
   - amd64
 startup: application
 boot: auto
-options: {}
-schema: {}
+options:
+  log_level: info
+  buffer_size: 100
+  incident_dir: /data/incidents
+schema:
+  log_level: list(trace|debug|info|warning|error|fatal)?
+  buffer_size: int
+  incident_dir: str

--- a/addons/ha-llm-ops/run.sh
+++ b/addons/ha-llm-ops/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -f /data/options.json ]; then
+  LOG_LEVEL=$(jq -r '.log_level // "info"' /data/options.json)
+  BUFFER_SIZE=$(jq -r '.buffer_size // 100' /data/options.json)
+  INCIDENT_DIR=$(jq -r '.incident_dir // "/data/incidents"' /data/options.json)
+else
+  LOG_LEVEL="info"
+  BUFFER_SIZE=100
+  INCIDENT_DIR="/data/incidents"
+fi
+
+echo "[ha-llm-ops] log_level=$LOG_LEVEL buffer_size=$BUFFER_SIZE incident_dir=$INCIDENT_DIR"
+
+env LOG_LEVEL="$LOG_LEVEL" BUFFER_SIZE="$BUFFER_SIZE" INCIDENT_DIR="$INCIDENT_DIR" \
+    exec python -m agent.main

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,0 +1,26 @@
+"""No-op agent loop for HA LLM Ops."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+
+def main() -> None:
+    """Run a no-op loop, logging heartbeats."""
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+    logger = logging.getLogger("ha_llm_ops.agent")
+    logger.info("agent starting")
+
+    try:
+        while True:
+            logger.debug("heartbeat")
+            time.sleep(60)
+    except KeyboardInterrupt:
+        logger.info("agent stopping")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dev = [
     "pytest-cov>=4.1",
     "ruff>=0.1.7",
     "mypy>=1.7",
-    "pre-commit>=3.4"
+    "pre-commit>=3.4",
+    "homeassistant>=2024.6.0"
 ]
 
 [tool.ruff]

--- a/tests/test_homeassistant_live.py
+++ b/tests/test_homeassistant_live.py
@@ -1,0 +1,51 @@
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import requests
+
+
+def _start_homeassistant() -> subprocess.Popen[str]:
+    config_dir = tempfile.mkdtemp()
+    Path(config_dir, "configuration.yaml").write_text("\n")
+    proc = subprocess.Popen(
+        [
+            "python",
+            "-m",
+            "homeassistant",
+            "--config",
+            config_dir,
+            "--skip-pip",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    url = "http://127.0.0.1:8123"
+    for _ in range(60):
+        try:
+            resp = requests.get(url, timeout=1)
+            if resp.status_code in {200, 401, 404}:
+                break
+        except requests.RequestException:
+            time.sleep(1)
+    else:
+        proc.terminate()
+        proc.wait(timeout=10)
+        raise RuntimeError("Home Assistant did not start in time")
+    return proc
+
+
+def test_homeassistant_runs_and_responds() -> None:
+    proc = _start_homeassistant()
+    try:
+        resp = requests.get("http://127.0.0.1:8123", timeout=5)
+        assert resp.status_code in {200, 401, 404}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)


### PR DESCRIPTION
## Summary
- implement add-on entrypoint with configurable logging and healthcheck
- include Python no-op agent loop and build it into the add-on image
- add integration test that spins up Home Assistant to verify connectivity

## Testing
- `pre-commit run --files addons/ha-llm-ops/run.sh addons/ha-llm-ops/Dockerfile addons/ha-llm-ops/config.yaml agent/main.py pyproject.toml tests/test_homeassistant_live.py .github/workflows/ci.yml` *(fails: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caa46a5ac8327bc3a6db39a6d9911