### PR TITLE
feat: add add-on skeleton with docker test

### DIFF
--- a/addons/ha-llm-ops/Dockerfile
+++ b/addons/ha-llm-ops/Dockerfile
@@ -1,2 +1,14 @@
 FROM alpine:3.19.1
-CMD ["/bin/sh", "-c", "echo Hello from HA LLM Ops add-on"]
+
+RUN apk add --no-cache python3 py3-pip jq
+
+WORKDIR /app
+COPY agent /app/agent
+ENV PYTHONPATH=/app
+
+COPY addons/ha-llm-ops/run.sh /run.sh
+RUN chmod +x /run.sh
+
+HEALTHCHECK --interval=30s --timeout=5s CMD [ -f /tmp/healthy ] || exit 1
+
+CMD ["/run.sh"]

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -7,5 +7,11 @@ arch:
   - amd64
 startup: application
 boot: auto
-options: {}
-schema: {}
+options:
+  log_level: info
+  buffer_size: 100
+  incident_dir: /data/incidents
+schema:
+  log_level: list(debug|info|warning|error)?
+  buffer_size: int
+  incident_dir: str

--- a/addons/ha-llm-ops/run.sh
+++ b/addons/ha-llm-ops/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+CONFIG_PATH=/data/options.json
+
+# Read options with jq; use defaults if file missing
+if [ -f "$CONFIG_PATH" ]; then
+  LOG_LEVEL=$(jq -r '.log_level // "INFO"' "$CONFIG_PATH")
+  BUFFER_SIZE=$(jq -r '.buffer_size // 100' "$CONFIG_PATH")
+  INCIDENT_DIR=$(jq -r '.incident_dir // "/data/incidents"' "$CONFIG_PATH")
+else
+  LOG_LEVEL=${LOG_LEVEL:-INFO}
+  BUFFER_SIZE=${BUFFER_SIZE:-100}
+  INCIDENT_DIR=${INCIDENT_DIR:-/data/incidents}
+fi
+
+export LOG_LEVEL BUFFER_SIZE INCIDENT_DIR
+
+echo "[INFO] Starting HA LLM Ops agent"  
+exec python3 -m agent

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -1,0 +1,30 @@
+"""Agent entrypoint with no-op loop."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    """Start the agent and run an idle loop."""
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+    buffer_size = os.environ.get("BUFFER_SIZE", "100")
+    incident_dir = os.environ.get("INCIDENT_DIR", "/data/incidents")
+    logging.info(
+        "Agent starting (log level: %s, buffer size: %s, incident dir: %s)",
+        log_level,
+        buffer_size,
+        incident_dir,
+    )
+    Path("/tmp/healthy").touch()
+    while True:
+        logging.debug("agent idle")
+        time.sleep(60)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ dev = [
     "pytest-cov>=4.1",
     "ruff>=0.1.7",
     "mypy>=1.7",
-    "pre-commit>=3.4"
+    "pre-commit>=3.4",
+    "requests>=2.31",
+    "types-requests"
 ]
 
 [tool.ruff]
@@ -27,6 +29,9 @@ select = ["E", "F", "I", "UP"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
+
+[tool.pytest.ini_options]
+markers = ["integration: mark tests requiring Docker"]
 
 [tool.setuptools]
 packages = ["agent"]

--- a/tests/test_home_assistant_docker.py
+++ b/tests/test_home_assistant_docker.py
@@ -1,0 +1,57 @@
+"""Integration test that talks to a real Home Assistant container."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+def _docker_available() -> bool:
+    """Return True if Docker CLI and daemon are available."""
+    if shutil.which("docker") is None:
+        return False
+    result = subprocess.run([
+        "docker",
+        "info",
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    return result.returncode == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available")
+def test_home_assistant_container() -> None:
+    """Start a Home Assistant container and verify the API responds."""
+    container_name = "ha-test"
+    port = "8123"
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            f"{port}:{port}",
+            "--name",
+            container_name,
+            "ghcr.io/home-assistant/home-assistant:stable",
+        ],
+        check=True,
+    )
+    base_url = f"http://localhost:{port}"
+    try:
+        for _ in range(60):
+            try:
+                resp = requests.get(f"{base_url}/api/")
+                if resp.status_code == 200:
+                    break
+            except requests.ConnectionError:
+                pass
+            time.sleep(1)
+        else:
+            pytest.fail("Home Assistant API did not respond in time")
+    finally:
+        subprocess.run(["docker", "stop", container_name], check=False)


### PR DESCRIPTION
## Summary
- implement add-on run script and Dockerfile with health check
- expose config options for log level, buffer size, and incident directory
- add Docker-based Home Assistant integration test

## Testing
- `ruff check agent/__main__.py tests/test_home_assistant_docker.py`
- `mypy agent/__main__.py tests/test_home_assistant_docker.py`
- `pytest`
- `pre-commit run --files addons/ha-llm-ops/run.sh addons/ha-llm-ops/Dockerfile addons/ha-llm-ops/config.yaml agent/__main__.py pyproject.toml tests/test_home_assistant_docker.py` *(fails: error: RPC failed; HTTP 403)*
- `docker build -f addons/ha-llm-ops/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb615de08327b7d3d759821ffe31