### PR TITLE
feat: add websocket observability

### DIFF
--- a/addons/ha-llm-ops/agent/__main__.py
+++ b/addons/ha-llm-ops/agent/__main__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
-import time
 from pathlib import Path
+
+from .observability import observe
 
 
 def main() -> None:
@@ -14,16 +16,17 @@ def main() -> None:
     logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
     buffer_size = os.environ.get("BUFFER_SIZE", "100")
     incident_dir = os.environ.get("INCIDENT_DIR", "/data/incidents")
+    ws_url = os.environ.get("HA_WS_URL", "ws://localhost:8123/api/websocket")
+    token = os.environ.get("SUPERVISOR_TOKEN", "")
     logging.info(
-        "Agent starting (log level: %s, buffer size: %s, incident dir: %s)",
+        "Agent starting (log level: %s, buffer size: %s, incident dir: %s, ws: %s)",
         log_level,
         buffer_size,
         incident_dir,
+        ws_url,
     )
     Path("/tmp/healthy").touch()
-    while True:
-        logging.debug("agent idle")
-        time.sleep(60)
+    asyncio.run(observe(ws_url, token, Path(incident_dir)))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual entry

--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -1,0 +1,92 @@
+"""WebSocket observability utilities for Home Assistant."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, TextIO
+
+import websockets
+
+from .redact import load_secret_keys, redact
+
+
+class IncidentLogger:
+    """Write events to rotating JSONL files."""
+
+    def __init__(self, directory: Path, max_bytes: int = 1_000_000) -> None:
+        self.directory = directory
+        self.max_bytes = max_bytes
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._counter = 0
+        self._file = self._open_file()
+
+    def _open_file(self) -> TextIO:
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        path = self.directory / f"incidents_{timestamp}_{self._counter}.jsonl"
+        self._counter += 1
+        return path.open("a", encoding="utf-8")
+
+    def write(self, event: dict[str, Any]) -> None:
+        line = json.dumps(event, sort_keys=True)
+        if self._file.tell() + len(line) + 1 > self.max_bytes:
+            self._file.close()
+            self._file = self._open_file()
+        self._file.write(line + "\n")
+        self._file.flush()
+
+
+async def _authenticate(ws: Any, token: str) -> None:
+    """Perform Home Assistant WebSocket authentication."""
+    msg = json.loads(await ws.recv())
+    if msg.get("type") != "auth_required":  # pragma: no cover - defensive
+        raise RuntimeError("unexpected auth sequence")
+    await ws.send(json.dumps({"type": "auth", "access_token": token}))
+    msg = json.loads(await ws.recv())
+    if msg.get("type") != "auth_ok":  # pragma: no cover - defensive
+        raise RuntimeError("authentication failed")
+
+
+async def observe(
+    url: str,
+    token: str,
+    incident_dir: Path,
+    *,
+    max_bytes: int = 1_000_000,
+    limit: int | None = None,
+    secrets_path: Path = Path("/config/secrets.yaml"),
+) -> None:
+    """Connect to the HA WebSocket API and persist selected events."""
+    secret_keys = load_secret_keys(secrets_path)
+    logger = IncidentLogger(incident_dir, max_bytes=max_bytes)
+    backoff = 1
+    processed = 0
+    while True:
+        try:
+            async with websockets.connect(url) as ws:
+                await _authenticate(ws, token)
+                await ws.send(json.dumps({"id": 1, "type": "subscribe_events"}))
+                async for message in ws:
+                    data = json.loads(message)
+                    if data.get("type") != "event":
+                        continue
+                    event = data.get("event", {})
+                    etype = event.get("event_type")
+                    if etype not in {"system_log_event", "trace"}:
+                        continue
+                    redacted = redact(event, secret_keys)
+                    logger.write(redacted)
+                    processed += 1
+                    if limit is not None and processed >= limit:
+                        return
+        except Exception as err:  # pragma: no cover - network error path
+            logging.exception("WebSocket error: %s", err)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+        else:  # pragma: no cover - connection closed gracefully
+            backoff = 1
+        if limit is not None and processed >= limit:
+            break

--- a/addons/ha-llm-ops/agent/redact.py
+++ b/addons/ha-llm-ops/agent/redact.py
@@ -1,0 +1,58 @@
+"""Utilities for redacting sensitive information from Home Assistant events."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_SECRET_KEYS = {
+    "token",
+    "access_token",
+    "refresh_token",
+    "password",
+    "api_key",
+    "authorization",
+    "client_secret",
+}
+
+TOKEN_PATTERNS = [re.compile(r"[A-Za-z0-9_-]{32,}")]
+
+
+def load_secret_keys(path: Path) -> set[str]:
+    """Load secret keys from a ``secrets.yaml`` file."""
+    try:
+        data = yaml.safe_load(path.read_text())
+    except FileNotFoundError:
+        return set()
+    if not isinstance(data, dict):  # pragma: no cover - defensive
+        return set()
+    return {str(k) for k in data.keys()}
+
+
+def _redact_str(value: str) -> str:
+    redacted = value
+    for pattern in TOKEN_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def redact(data: Any, secret_keys: Iterable[str]) -> Any:
+    """Recursively redact secrets from ``data``."""
+    secrets = set(DEFAULT_SECRET_KEYS).union(set(secret_keys))
+    if isinstance(data, dict):
+        result: dict[str, Any] = {}
+        for key, value in data.items():
+            if key in secrets:
+                result[key] = "[redacted]"
+            else:
+                result[key] = redact(value, secrets)
+        return result
+    if isinstance(data, list):
+        return [redact(item, secrets) for item in data]
+    if isinstance(data, str):
+        return _redact_str(data)
+    return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ version = "0.0.0"
 description = "HA LLM Ops agent"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "websockets>=12.0",
+    "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -18,7 +21,8 @@ dev = [
     "mypy>=1.7",
     "pre-commit>=3.4",
     "requests>=2.31",
-    "types-requests"
+    "types-requests",
+    "types-PyYAML",
 ]
 
 [tool.ruff]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,83 @@
+import asyncio
+import json
+from pathlib import Path
+
+import websockets
+
+from agent.observability import observe
+
+
+def _event(event_type: str, data: dict) -> dict:
+    return {"type": "event", "event": {"event_type": event_type, "data": data}}
+
+
+async def _serve(events: list[dict]) -> str:
+    async def handler(ws):
+        await ws.send(json.dumps({"type": "auth_required"}))
+        await ws.recv()  # auth
+        await ws.send(json.dumps({"type": "auth_ok"}))
+        await ws.recv()  # subscribe
+        for evt in events:
+            await ws.send(json.dumps(evt))
+        await asyncio.sleep(0.1)
+
+    server = await websockets.serve(handler, "localhost", 0)
+    port = server.sockets[0].getsockname()[1]
+    return server, f"ws://localhost:{port}"
+
+
+def test_observe_writes_redacted_events(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets.yaml"
+    secrets.write_text("api_key: supersecret\npassword: hidden\n")
+
+    events = [
+        _event(
+            "system_log_event",
+            {
+                "message": "token ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+                "api_key": "supersecret",
+            },
+        ),
+        _event(
+            "trace",
+            {"details": "something secret", "password": "hidden"},
+        ),
+        _event(
+            "system_log_event",
+            {
+                "message": "another token ZZZZYYYYXXXXWWWWVVVVUUUUTTTT",
+                "api_key": "supersecret",
+            },
+        ),
+    ]
+
+    async def run_test() -> None:
+        server, url = await _serve(events)
+        try:
+            await observe(
+                url,
+                token="t",
+                incident_dir=tmp_path,
+                max_bytes=120,
+                limit=3,
+                secrets_path=secrets,
+            )
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(run_test())
+
+    files = sorted(tmp_path.glob("incidents_*.jsonl"))
+    assert len(files) >= 2  # rotation happened
+
+    lines = []
+    for file in files:
+        lines.extend(json.loads(line) for line in file.read_text().splitlines())
+
+    assert len(lines) == 3
+    for line in lines:
+        dumped = json.dumps(line)
+        assert "supersecret" not in dumped
+        assert "hidden" not in dumped
+        assert "[redacted]" in dumped


### PR DESCRIPTION
## Summary
- implement websocket observer with rotating JSONL logs
- redact tokens and secrets before persisting events
- cover websocket logging with unit test

## Testing
- `make lint`
- `make test` *(fails: pre-commit `git fetch` 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d02f02fd88327944ec7f2386bb2e3