### PR TITLE
Handle HA error, failure, and unavailability events

### DIFF
--- a/tests/test_home_assistant_docker.py
+++ b/tests/test_home_assistant_docker.py
@@ -44,7 +44,7 @@ def test_home_assistant_container() -> None:
     base_url = f"http://localhost:{port}"
     try:
         # Wait for the onboarding endpoint to come up
-        for _ in range(180):
+        for _ in range(300):
             try:
                 resp = requests.get(f"{base_url}/api/onboarding", timeout=1)
                 if resp.status_code == 200:

--- a/tests/test_home_assistant_docker.py
+++ b/tests/test_home_assistant_docker.py
@@ -7,7 +7,6 @@ import subprocess
 import time
 
 import pytest
-import requests
 
 
 def _docker_available() -> bool:
@@ -25,6 +24,8 @@ def _docker_available() -> bool:
 @pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available")
 def test_home_assistant_container() -> None:
     """Start a Home Assistant container and verify the API responds."""
+    import requests
+
     container_name = "ha-test"
     port = "8123"
     subprocess.run(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -34,19 +34,39 @@ def test_observe_writes_redacted_events(tmp_path: Path) -> None:
         _event(
             "system_log_event",
             {
+                "level": 50,
                 "message": "token ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
                 "api_key": "supersecret",
             },
         ),
         _event(
-            "trace",
-            {"details": "something secret", "password": "hidden"},
-        ),
-        _event(
             "system_log_event",
             {
-                "message": "another token ZZZZYYYYXXXXWWWWVVVVUUUUTTTT",
+                "level": 20,
+                "message": "ignored",
                 "api_key": "supersecret",
+            },
+        ),
+        _event(
+            "trace",
+            {
+                "result": {"success": False, "error": "boom"},
+                "password": "hidden",
+            },
+        ),
+        _event("trace", {"result": {"success": True}}),
+        _event(
+            "state_changed",
+            {
+                "entity_id": "sensor.x",
+                "new_state": {"state": "unavailable", "token": "ZZZZYYYY"},
+            },
+        ),
+        _event(
+            "state_changed",
+            {
+                "entity_id": "sensor.x",
+                "new_state": {"state": "on"},
             },
         ),
     ]
@@ -76,8 +96,14 @@ def test_observe_writes_redacted_events(tmp_path: Path) -> None:
         lines.extend(json.loads(line) for line in file.read_text().splitlines())
 
     assert len(lines) == 3
+    assert {line["event_type"] for line in lines} == {
+        "system_log_event",
+        "trace",
+        "state_changed",
+    }
     for line in lines:
         dumped = json.dumps(line)
         assert "supersecret" not in dumped
         assert "hidden" not in dumped
+        assert "ZZZZYYYY" not in dumped
         assert "[redacted]" in dumped

--- a/tests/test_observability_docker.py
+++ b/tests/test_observability_docker.py
@@ -133,8 +133,7 @@ def test_observe_automation_failure(tmp_path: Path) -> None:
         assert any(
             (
                 line.get("event_type") == "system_log_event"
-                and "nonexistent.does_not_exist"
-                in line.get("data", {}).get("message", "")
+                and "nonexistent.does_not_exist" in json.dumps(line)
             )
             or (
                 line.get("event_type") == "trace"

--- a/tests/test_observability_docker.py
+++ b/tests/test_observability_docker.py
@@ -1,0 +1,135 @@
+import asyncio
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from agent.observability import observe
+
+
+def _docker_available() -> bool:
+    """Return True if Docker CLI and daemon are available."""
+    if shutil.which("docker") is None:
+        return False
+    result = subprocess.run(
+        ["docker", "info"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available")
+def test_observe_automation_failure(tmp_path: Path) -> None:
+    """Ensure observer logs an automation failure from a real HA container."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "secrets.yaml").write_text("")
+    (config_dir / "configuration.yaml").write_text(
+        "automation: !include automations.yaml\n"
+    )
+    (config_dir / "automations.yaml").write_text(
+        """
+- id: fail_test
+  alias: Fail Test
+  trigger:
+    - platform: time_pattern
+      seconds: "/1"
+  action:
+    - service: nonexistent.does_not_exist
+"""
+    )
+
+    container_name = "ha-observe-test"
+    port = "8125"
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            f"{port}:{port}",
+            "-v",
+            f"{config_dir}:/config",  # type: ignore[arg-type]
+            "--name",
+            container_name,
+            "ghcr.io/home-assistant/home-assistant:stable",
+        ],
+        check=True,
+    )
+    base_url = f"http://localhost:{port}"
+    ws_url = f"ws://localhost:{port}/api/websocket"
+    try:
+        for _ in range(180):
+            try:
+                resp = requests.get(f"{base_url}/api/onboarding", timeout=1)
+                if resp.status_code == 200:
+                    break
+            except requests.ConnectionError:
+                pass
+            time.sleep(1)
+        else:
+            pytest.fail("Home Assistant API did not respond in time")
+
+        client_id = "http://example"
+        resp = requests.post(
+            f"{base_url}/api/onboarding/users",
+            json={
+                "client_id": client_id,
+                "name": "Test Name",
+                "username": "test-user",
+                "password": "test-pass",
+                "language": "en",
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        auth_code = resp.json()["auth_code"]
+
+        resp = requests.post(
+            f"{base_url}/auth/token",
+            data={
+                "client_id": client_id,
+                "grant_type": "authorization_code",
+                "code": auth_code,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        token = resp.json()["access_token"]
+
+        incident_dir = tmp_path / "incidents"
+        asyncio.run(
+            asyncio.wait_for(
+                observe(
+                    ws_url,
+                    token=token,
+                    incident_dir=incident_dir,
+                    limit=1,
+                    secrets_path=config_dir / "secrets.yaml",
+                ),
+                timeout=60,
+            )
+        )
+
+        files = list(incident_dir.glob("incidents_*.jsonl"))
+        assert files, "No incident files created"
+        lines = [
+            json.loads(line)
+            for file in files
+            for line in file.read_text().splitlines()
+        ]
+        assert any(
+            line.get("event_type") == "system_log_event"
+            and "nonexistent.does_not_exist" in line.get("data", {}).get("message", "")
+            for line in lines
+        ), lines
+    finally:
+        subprocess.run(["docker", "stop", container_name], check=False)

--- a/tests/test_observability_docker.py
+++ b/tests/test_observability_docker.py
@@ -67,7 +67,7 @@ def test_observe_automation_failure(tmp_path: Path) -> None:
     base_url = f"http://localhost:{port}"
     ws_url = f"ws://localhost:{port}/api/websocket"
     try:
-        for _ in range(180):
+        for _ in range(300):
             try:
                 resp = requests.get(f"{base_url}/api/onboarding", timeout=1)
                 if resp.status_code == 200:
@@ -115,7 +115,7 @@ def test_observe_automation_failure(tmp_path: Path) -> None:
                     limit=1,
                     secrets_path=config_dir / "secrets.yaml",
                 ),
-                timeout=60,
+                timeout=180,
             )
         )
 

--- a/tests/test_observability_docker.py
+++ b/tests/test_observability_docker.py
@@ -55,7 +55,7 @@ def test_observe_automation_failure(tmp_path: Path) -> None:
             "-d",
             "--rm",
             "-p",
-            f"{port}:{port}",
+            f"{port}:8123",
             "-v",
             f"{config_dir}:/config",  # type: ignore[arg-type]
             "--name",


### PR DESCRIPTION
## Summary
- Notify observer when Home Assistant logs errors, automation/script runs fail, or entities become unavailable
- Extend observability test to simulate these failure scenarios and ensure redaction

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d60a8a93c8327a35b7a5004dc7fba