### PR TITLE
feat: add RCA contract and prompt builder

### DIFF
--- a/addons/ha-llm-ops/agent/contracts/__init__.py
+++ b/addons/ha-llm-ops/agent/contracts/__init__.py
@@ -1,0 +1,6 @@
+"""Pydantic contracts for agent prompts and responses."""
+
+from .rca import CandidateAction, RcaResult
+
+__all__ = ["CandidateAction", "RcaResult"]
+

--- a/addons/ha-llm-ops/agent/contracts/rca.py
+++ b/addons/ha-llm-ops/agent/contracts/rca.py
@@ -1,0 +1,51 @@
+"""Root cause analysis contract and JSON schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field, confloat
+
+
+class CandidateAction(BaseModel):
+    """A potential action to mitigate the incident."""
+
+    action: str = Field(..., description="Short description of the action")
+    rationale: str = Field(..., description="Why the action may help")
+
+
+class RcaResult(BaseModel):
+    """LLM-provided root cause analysis result."""
+
+    root_cause: str = Field(..., description="Primary reason for the incident")
+    impact: str = Field(..., description="Observed impact on the system")
+    confidence: confloat(ge=0.0, le=1.0) = Field(
+        ..., description="Confidence score between 0 and 1"
+    )
+    candidate_actions: list[CandidateAction] = Field(
+        default_factory=list, description="Proposed remediation steps"
+    )
+    risk: str = Field(..., description="Overall risk assessment of acting")
+    tests: list[str] = Field(
+        default_factory=list,
+        description="Checks to verify the issue is resolved",
+    )
+
+
+def export_schema(path: Path | None = None) -> Path:
+    """Export the JSON schema to ``rca_v1.json`` and return its path."""
+
+    schema = RcaResult.model_json_schema()
+    if path is None:
+        path = Path(__file__).with_name("rca_v1.json")
+    content = json.dumps(schema, indent=2) + "\n"
+    existing = path.read_text() if path.exists() else ""
+    if existing != content:
+        path.write_text(content)
+    return path
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    export_schema()
+

--- a/addons/ha-llm-ops/agent/contracts/rca.py
+++ b/addons/ha-llm-ops/agent/contracts/rca.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pydantic import BaseModel, Field, confloat
+from typing import Annotated
+
+from pydantic import BaseModel, Field
 
 
 class CandidateAction(BaseModel):
@@ -20,9 +22,9 @@ class RcaResult(BaseModel):
 
     root_cause: str = Field(..., description="Primary reason for the incident")
     impact: str = Field(..., description="Observed impact on the system")
-    confidence: confloat(ge=0.0, le=1.0) = Field(
-        ..., description="Confidence score between 0 and 1"
-    )
+    confidence: Annotated[
+        float, Field(ge=0.0, le=1.0, description="Confidence score between 0 and 1")
+    ]
     candidate_actions: list[CandidateAction] = Field(
         default_factory=list, description="Proposed remediation steps"
     )

--- a/addons/ha-llm-ops/agent/contracts/rca.py
+++ b/addons/ha-llm-ops/agent/contracts/rca.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-
 from typing import Annotated
 
 from pydantic import BaseModel, Field

--- a/addons/ha-llm-ops/agent/contracts/rca_v1.json
+++ b/addons/ha-llm-ops/agent/contracts/rca_v1.json
@@ -1,0 +1,74 @@
+{
+  "$defs": {
+    "CandidateAction": {
+      "description": "A potential action to mitigate the incident.",
+      "properties": {
+        "action": {
+          "description": "Short description of the action",
+          "title": "Action",
+          "type": "string"
+        },
+        "rationale": {
+          "description": "Why the action may help",
+          "title": "Rationale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action",
+        "rationale"
+      ],
+      "title": "CandidateAction",
+      "type": "object"
+    }
+  },
+  "description": "LLM-provided root cause analysis result.",
+  "properties": {
+    "root_cause": {
+      "description": "Primary reason for the incident",
+      "title": "Root Cause",
+      "type": "string"
+    },
+    "impact": {
+      "description": "Observed impact on the system",
+      "title": "Impact",
+      "type": "string"
+    },
+    "confidence": {
+      "description": "Confidence score between 0 and 1",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "candidate_actions": {
+      "description": "Proposed remediation steps",
+      "items": {
+        "$ref": "#/$defs/CandidateAction"
+      },
+      "title": "Candidate Actions",
+      "type": "array"
+    },
+    "risk": {
+      "description": "Overall risk assessment of acting",
+      "title": "Risk",
+      "type": "string"
+    },
+    "tests": {
+      "description": "Checks to verify the issue is resolved",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tests",
+      "type": "array"
+    }
+  },
+  "required": [
+    "root_cause",
+    "impact",
+    "confidence",
+    "risk"
+  ],
+  "title": "RcaResult",
+  "type": "object"
+}

--- a/addons/ha-llm-ops/agent/prompt.py
+++ b/addons/ha-llm-ops/agent/prompt.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from .contracts import RcaResult
 

--- a/addons/ha-llm-ops/agent/prompt.py
+++ b/addons/ha-llm-ops/agent/prompt.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import json
+from typing import Any, Mapping
 
 from .contracts import RcaResult
 
 
-def build_rca_prompt(context: dict) -> str:
+def build_rca_prompt(context: Mapping[str, Any]) -> str:
     """Return a prompt instructing the LLM to produce an :class:`RcaResult`.
 
     Parameters
     ----------
-    context: dict
+    context: Mapping[str, Any]
         Incident context gathered from Home Assistant.
     """
 

--- a/addons/ha-llm-ops/agent/prompt.py
+++ b/addons/ha-llm-ops/agent/prompt.py
@@ -1,0 +1,30 @@
+"""Utilities to build LLM prompts."""
+
+from __future__ import annotations
+
+import json
+
+from .contracts import RcaResult
+
+
+def build_rca_prompt(context: dict) -> str:
+    """Return a prompt instructing the LLM to produce an :class:`RcaResult`.
+
+    Parameters
+    ----------
+    context: dict
+        Incident context gathered from Home Assistant.
+    """
+
+    schema = json.dumps(RcaResult.model_json_schema(), indent=2)
+    ctx = json.dumps(context, indent=2)
+    return (
+        "You are a Home Assistant diagnostics agent. "
+        "Analyze the incident and respond with JSON matching the schema below.\n\n"
+        f"Schema:\n{schema}\n\n"
+        f"Context:\n{ctx}\n"
+    )
+
+
+__all__ = ["build_rca_prompt"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dev = [
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ strict = true
 
 [tool.pytest.ini_options]
 markers = ["integration: mark tests requiring Docker"]
+pythonpath = ["."]
 
 [tool.setuptools]
 packages = ["agent"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "websockets>=12.0",
     "PyYAML>=6.0",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/golden/rca_invalid.json
+++ b/tests/golden/rca_invalid.json
@@ -1,0 +1,8 @@
+{
+  "root_cause": "something",
+  "impact": "bad things",
+  "confidence": 1.2,
+  "candidate_actions": [],
+  "risk": "unknown"
+}
+

--- a/tests/golden/rca_valid.json
+++ b/tests/golden/rca_valid.json
@@ -1,0 +1,17 @@
+{
+  "root_cause": "misconfigured integration X",
+  "impact": "automation Y fails to run",
+  "confidence": 0.8,
+  "candidate_actions": [
+    {
+      "action": "reload integration X",
+      "rationale": "reset configuration"
+    }
+  ],
+  "risk": "low",
+  "tests": [
+    "integration X responds",
+    "automation Y executes"
+  ]
+}
+

--- a/tests/snapshots/rca_prompt.txt
+++ b/tests/snapshots/rca_prompt.txt
@@ -1,0 +1,87 @@
+You are a Home Assistant diagnostics agent. Analyze the incident and respond with JSON matching the schema below.
+
+Schema:
+{
+  "$defs": {
+    "CandidateAction": {
+      "description": "A potential action to mitigate the incident.",
+      "properties": {
+        "action": {
+          "description": "Short description of the action",
+          "title": "Action",
+          "type": "string"
+        },
+        "rationale": {
+          "description": "Why the action may help",
+          "title": "Rationale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action",
+        "rationale"
+      ],
+      "title": "CandidateAction",
+      "type": "object"
+    }
+  },
+  "description": "LLM-provided root cause analysis result.",
+  "properties": {
+    "root_cause": {
+      "description": "Primary reason for the incident",
+      "title": "Root Cause",
+      "type": "string"
+    },
+    "impact": {
+      "description": "Observed impact on the system",
+      "title": "Impact",
+      "type": "string"
+    },
+    "confidence": {
+      "description": "Confidence score between 0 and 1",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "candidate_actions": {
+      "description": "Proposed remediation steps",
+      "items": {
+        "$ref": "#/$defs/CandidateAction"
+      },
+      "title": "Candidate Actions",
+      "type": "array"
+    },
+    "risk": {
+      "description": "Overall risk assessment of acting",
+      "title": "Risk",
+      "type": "string"
+    },
+    "tests": {
+      "description": "Checks to verify the issue is resolved",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tests",
+      "type": "array"
+    }
+  },
+  "required": [
+    "root_cause",
+    "impact",
+    "confidence",
+    "risk"
+  ],
+  "title": "RcaResult",
+  "type": "object"
+}
+
+Context:
+{
+  "events": [
+    {
+      "event_type": "system_log_event",
+      "message": "boom"
+    }
+  ]
+}

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from agent.prompt import build_rca_prompt
+
+
+def test_build_rca_prompt_snapshot() -> None:
+    context = {"events": [{"event_type": "system_log_event", "message": "boom"}]}
+    prompt = build_rca_prompt(context)
+    snapshot = Path("tests/snapshots/rca_prompt.txt").read_text()
+    assert prompt == snapshot
+

--- a/tests/test_rca_contract.py
+++ b/tests/test_rca_contract.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agent.contracts import RcaResult
+
+
+def test_schema_matches_export() -> None:
+    schema_path = Path("agent/contracts/rca_v1.json")
+    exported = json.loads(schema_path.read_text())
+    assert exported == RcaResult.model_json_schema()
+
+
+@pytest.mark.parametrize(
+    "sample_path,expect_valid",
+    [
+        ("tests/golden/rca_valid.json", True),
+        ("tests/golden/rca_invalid.json", False),
+    ],
+)
+def test_vectors(sample_path: str, expect_valid: bool) -> None:
+    data = json.loads(Path(sample_path).read_text())
+    if expect_valid:
+        RcaResult.model_validate(data)
+    else:
+        with pytest.raises(ValidationError):
+            RcaResult.model_validate(data)
+


### PR DESCRIPTION
## Summary
- define RCA contract with Pydantic models and exported JSON schema
- add prompt builder for RCA and snapshot tests
- validate schema with golden vectors

## Testing
- `pytest`
- `pre-commit run --files pyproject.toml addons/ha-llm-ops/agent/contracts/__init__.py addons/ha-llm-ops/agent/contracts/rca.py addons/ha-llm-ops/agent/contracts/rca_v1.json addons/ha-llm-ops/agent/prompt.py tests/golden/rca_valid.json tests/golden/rca_invalid.json tests/snapshots/rca_prompt.txt tests/test_rca_contract.py tests/test_prompt_builder.py` *(fails: 403 fetching pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_689e2a4557408327b16780c892748445