### PR TITLE
feat: list incidents via http endpoint

### DIFF
--- a/addons/ha-llm-ops/agent/__main__.py
+++ b/addons/ha-llm-ops/agent/__main__.py
@@ -7,6 +7,7 @@ import logging
 import os
 from pathlib import Path
 
+from .devux import start_http_server
 from .observability import observe
 
 
@@ -26,6 +27,7 @@ def main() -> None:
         ws_url,
     )
     Path("/tmp/healthy").touch()
+    start_http_server(Path(incident_dir))
     asyncio.run(observe(ws_url, token, Path(incident_dir)))
 
 

--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -1,0 +1,48 @@
+"""Development UX utilities like a minimal HTTP incident endpoint."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def list_incidents(directory: Path) -> list[str]:
+    """Return sorted incident bundle file names."""
+    return sorted(p.name for p in directory.glob("incidents_*.jsonl"))
+
+
+def start_http_server(
+    directory: Path, host: str = "0.0.0.0", port: int = 8000
+) -> ThreadingHTTPServer:
+    """Start a thread-based HTTP server exposing incident bundles.
+
+    The server provides a single endpoint ``/incidents`` returning a JSON list of
+    bundles found in ``directory``. It runs in a background thread and returns the
+    server instance for optional shutdown.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path.rstrip("/") != "/incidents":
+                self.send_response(404)
+                self.end_headers()
+                return
+            bundles = list_incidents(directory)
+            body = json.dumps(bundles).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(
+            self, format: str, *args: object
+        ) -> None:  # pragma: no cover - noise
+            return
+
+    server = ThreadingHTTPServer((host, port), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server

--- a/docs/example_lovelace_card.yaml
+++ b/docs/example_lovelace_card.yaml
@@ -1,0 +1,18 @@
+# Example Lovelace setup polling the agent's incident endpoint.
+#
+# Define a REST sensor in configuration.yaml:
+# sensor:
+#   - platform: rest
+#     name: incident_bundles
+#     resource: http://localhost:8000/incidents
+#     scan_interval: 30
+#
+# Then add this card to your dashboard:
+type: markdown
+title: Agent Incidents
+content: |
+  {% set incidents = states('sensor.incident_bundles') | from_json %}
+  {% for inc in incidents %}
+  - {{ inc }}
+  {% endfor %}
+

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -1,0 +1,21 @@
+import time
+from pathlib import Path
+
+import requests
+
+from agent.devux import start_http_server
+
+
+def test_http_lists_incident_files(tmp_path: Path) -> None:
+    (tmp_path / "incidents_1.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "incidents_2.jsonl").write_text("{}\n", encoding="utf-8")
+    server = start_http_server(tmp_path, host="127.0.0.1", port=0)
+    try:
+        # Allow server thread to start
+        time.sleep(0.1)
+        port = server.server_address[1]
+        resp = requests.get(f"http://127.0.0.1:{port}/incidents", timeout=5)
+        assert resp.status_code == 200
+        assert resp.json() == ["incidents_1.jsonl", "incidents_2.jsonl"]
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- add lightweight HTTP server to list incident bundles
- start incident listing endpoint from agent entrypoint
- document and test the new endpoint, plus example Lovelace card

## Testing
- `make format`
- `make lint`
- `make test`
- `make pre-commit` *(fails: error: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e406317d483278ffd2a6b88b4f906