### PR TITLE
feat: add analysis foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,144 +218,116 @@ Below are ready-to-run bite-sized tasks for the autonomous agent. Each bullet is
 
 ### M1.0 – Analysis skeleton & contracts
 
-1.  **Task:** Create `agent/analysis/__init__.py` and `agent/analysis/types.py`.
-    
-    -   Define typed structures for: `IncidentRef`, `ContextBundle`, `Prompt`, `RcaOutput` (alias of `RcaResult`).
-        
-    -   Add unit tests validating simple constructors and type hints (mypy strict).
-        
-2.  **Task:** Add `agent/analysis/storage.py`.
-    
-    -   Read incident files from `/data/incidents`.
-        
-    -   Map to `IncidentRef` (filename + time range).
-        
-    -   Unit tests with tmpdir fixtures (empty dir, multiple files, malformed line handling).
-        
-3.  **Task:** Add `agent/analysis/context.py`.
-    
-    -   Build `ContextBundle` from recent events around an incident (last N lines), deduplicate noisy repeats, enforce redaction.
-        
-    -   Unit tests: verify redaction, dedupe, size limits.
-        
+1. **Task:** Create `agent/analysis/__init__.py` and `agent/analysis/types.py`.
+
+    - Define typed structures for: `IncidentRef`, `ContextBundle`, `Prompt`, `RcaOutput` (alias of `RcaResult`).
+    - Add unit tests validating simple constructors and type hints (mypy strict).
+
+1. **Task:** Add `agent/analysis/storage.py`.
+
+    - Read incident files from `/data/incidents`.
+    - Map to `IncidentRef` (filename + time range).
+    - Unit tests with tmpdir fixtures (empty dir, multiple files, malformed line handling).
+
+1. **Task:** Add `agent/analysis/context.py`.
+
+    - Build `ContextBundle` from recent events around an incident (last N lines), deduplicate noisy repeats, enforce redaction.
+    - Unit tests: verify redaction, dedupe, size limits.
 
 ### M1.1 – Prompt builder
 
-4.  **Task:** Add `agent/analysis/prompt_builder.py`.
-    
-    -   Deterministic prompt from `ContextBundle` + repo/version info + guardrails.
-        
-    -   Export prompt as **pure text** plus a **JSON schema section** (copied from `RcaResult.model_json_schema()`).
-        
-5.  **Task:** Golden tests for prompt builder.
-    
-    -   Create `tests/golden/prompt_input.json` and `tests/golden/prompt_output.txt`.
-        
-    -   Snapshot test ensuring prompt text matches exactly; add an allowlisted small “update snapshot” script.
-        
+1. **Task:** Add `agent/analysis/prompt_builder.py`.
+
+    - Deterministic prompt from `ContextBundle` + repo/version info + guardrails.
+    - Export prompt as **pure text** plus a **JSON schema section** (copied from `RcaResult.model_json_schema()`).
+
+1. **Task:** Golden tests for prompt builder.
+
+    - Create `tests/golden/prompt_input.json` and `tests/golden/prompt_output.txt`.
+    - Snapshot test ensuring prompt text matches exactly; add an allowlisted small “update snapshot” script.
 
 ### M1.2 – LLM adapters (read-only)
 
-6.  **Task:** Create `agent/analysis/llm/base.py`.
-    
-    -   Define `LLM` protocol: `generate(prompt: str, *, timeout: float) -> str`.
-        
-7.  **Task:** Add `agent/analysis/llm/mock.py`.
-    
-    -   Deterministic stub returning a canned, valid `RcaResult` JSON for tests.
-        
-8.  **Task:** Add `agent/analysis/llm/openai.py` (adapter only).
-    
-    -   Read `OPENAI_API_KEY` from env.
-        
-    -   Compose JSON-only system prompt: “Respond with **only** valid JSON per schema below; no prose.”
-        
-    -   Parse/return raw string (no model validation here).
-        
-    -   Unit tests: environment handling + timeouts (use mock HTTP).
-        
-9.  **Task:** Add `agent/analysis/parse.py`.
-    
-    -   Strict parsing: JSON load → pydantic `RcaResult`.
-        
-    -   Defensive errors surfaced with actionable messages.
-        
-    -   Unit tests with valid/invalid payloads.
-        
+1. **Task:** Create `agent/analysis/llm/base.py`.
+
+    - Define `LLM` protocol: `generate(prompt: str, *, timeout: float) -> str`.
+
+1. **Task:** Add `agent/analysis/llm/mock.py`.
+
+    - Deterministic stub returning a canned, valid `RcaResult` JSON for tests.
+
+1. **Task:** Add `agent/analysis/llm/openai.py` (adapter only).
+
+    - Read `OPENAI_API_KEY` from env.
+    - Compose JSON-only system prompt: “Respond with **only** valid JSON per schema below; no prose.”
+    - Parse/return raw string (no model validation here).
+    - Unit tests: environment handling + timeouts (use mock HTTP).
+
+1. **Task:** Add `agent/analysis/parse.py`.
+
+    - Strict parsing: JSON load → pydantic `RcaResult`.
+    - Defensive errors surfaced with actionable messages.
+    - Unit tests with valid/invalid payloads.
 
 ### M1.3 – Analysis runner & endpoints
 
-10.  **Task:** Add `agent/analysis/runner.py`.
-    
-    -   Scheduler: scan for new incident files; rate-limit; enqueue to analyze; backoff on failures.
-        
-    -   Pluggable LLM (`MOCK` default, `OPENAI` if env present).
-        
-    -   Persist analyses as JSONL in `/data/analyses/analyses_*.jsonl` (size-rotated).
-        
-    -   Unit tests: queueing, rate-limit, rotation.
-        
-11.  **Task:** Extend HTTP server in `agent/devux.py`.
-    
-    -   Add GET `/analyses` → returns latest analyses (filenames or inline last N).
-        
-    -   Unit tests for handler (404, empty, non-empty).
-        
-12.  **Task:** Wire the runner in `addons/ha-llm-ops/agent/__main__.py`.
-    
-    -   Start analysis runner alongside observer and HTTP server.
-        
-    -   Config via env: `ANALYSIS_RATE_SECONDS`, `ANALYSIS_MAX_LINES`, `LLM_BACKEND`.
-        
-    -   Unit test: start/stop with mock LLM; verify runner called.
-        
+1. **Task:** Add `agent/analysis/runner.py`.
+
+    - Scheduler: scan for new incident files; rate-limit; enqueue to analyze; backoff on failures.
+    - Pluggable LLM (`MOCK` default, `OPENAI` if env present).
+    - Persist analyses as JSONL in `/data/analyses/analyses_*.jsonl` (size-rotated).
+    - Unit tests: queueing, rate-limit, rotation.
+
+1. **Task:** Extend HTTP server in `agent/devux.py`.
+
+    - Add GET `/analyses` → returns latest analyses (filenames or inline last N).
+    - Unit tests for handler (404, empty, non-empty).
+
+1. **Task:** Wire the runner in `addons/ha-llm-ops/agent/__main__.py`.
+
+    - Start analysis runner alongside observer and HTTP server.
+    - Config via env: `ANALYSIS_RATE_SECONDS`, `ANALYSIS_MAX_LINES`, `LLM_BACKEND`.
+    - Unit test: start/stop with mock LLM; verify runner called.
 
 ### M1.4 – End-to-end & integration
 
-13.  **Task:** Add E2E test with **mock LLM** (no network).
-    
-    -   Create a synthetic incident file; run runner once; assert a valid `RcaResult` stored; verify `/analyses` lists it.
-        
-14.  **Task:** Extend Docker-based HA integration test.
-    
-    -   After generating at least one incident, run the analysis once with mock LLM; assert a persisted analysis appears.
-        
-15.  **Task:** Coverage & CI
-    
-    -   Raise coverage threshold to 85% for analysis modules.
-        
-    -   Ensure CI skips real LLM tests unless `OPENAI_API_KEY` is set (matrix job optional).
-        
+1. **Task:** Add E2E test with **mock LLM** (no network).
+
+    - Create a synthetic incident file; run runner once; assert a valid `RcaResult` stored; verify `/analyses` lists it.
+
+1. **Task:** Extend Docker-based HA integration test.
+
+    - After generating at least one incident, run the analysis once with mock LLM; assert a persisted analysis appears.
+
+1. **Task:** Coverage & CI
+
+    - Raise coverage threshold to 85% for analysis modules.
+    - Ensure CI skips real LLM tests unless `OPENAI_API_KEY` is set (matrix job optional).
 
 ### M1.5 – Minimal UI
 
-16.  **Task:** Add example Lovelace card YAML (docs/):
-    
-    -   Panel listing `/analyses` newest-first; clicking an item shows parsed `RcaResult`.
-        
-17.  **Task:** Documentation: user & dev guides.
-    
-    -   How to enable mock vs. real LLM, env vars, expected endpoints, sample flows.
-        
+1. **Task:** Add example Lovelace card YAML (docs/):
+
+    - Panel listing `/analyses` newest-first; clicking an item shows parsed `RcaResult`.
+
+1. **Task:** Documentation: user & dev guides.
+
+    - How to enable mock vs. real LLM, env vars, expected endpoints, sample flows.
 
 ----------
 
 ## Non-Goals for M1
 
--   No mutating actions (service calls, restarts, reauth)
-    
--   No policy file or executor (M2)
-    
--   No telemetry collection
+- No mutating actions (service calls, restarts, reauth)
+- No policy file or executor (M2)
+- No telemetry collection
 
 ----------
 
 ## Environment Variables (planned)
 
 - `HA_WS_URL` – HA WebSocket URL (dev mode only; add-on will auto-use Supervisor token/URL).
-
 - `SUPERVISOR_TOKEN` – injected by HA when running as an add-on (do not set manually).
-
 - `INCIDENT_DIR` – default `/data/incidents`.
 
 - `LOG_LEVEL` – default `INFO`.

--- a/addons/ha-llm-ops/agent/analysis/__init__.py
+++ b/addons/ha-llm-ops/agent/analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Analysis package exposing core types."""
+
+from .types import ContextBundle, IncidentRef, Prompt, RcaOutput
+
+__all__ = ["ContextBundle", "IncidentRef", "Prompt", "RcaOutput"]

--- a/addons/ha-llm-ops/agent/analysis/context.py
+++ b/addons/ha-llm-ops/agent/analysis/context.py
@@ -1,0 +1,46 @@
+"""Build context bundles from incident files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..redact import load_secret_keys, redact
+from .types import ContextBundle, IncidentRef
+
+
+def build_context(
+    incident: IncidentRef,
+    *,
+    max_lines: int = 50,
+    secrets_path: Path = Path("/config/secrets.yaml"),
+) -> ContextBundle:
+    """Return a ``ContextBundle`` for ``incident``.
+
+    Reads the incident file, selects the last ``max_lines`` entries, applies
+    redaction, and deduplicates consecutive duplicate events.
+    """
+
+    secret_keys = load_secret_keys(secrets_path)
+    try:
+        lines = incident.path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:  # pragma: no cover - defensive
+        lines = []
+
+    events: list[dict[str, Any]] = []
+    last_cmp: dict[str, Any] | None = None
+    for line in lines[-max_lines:]:
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        redacted = redact(data, secret_keys)
+        cmp = {k: v for k, v in redacted.items() if k != "time_fired"}
+        if last_cmp != cmp:
+            events.append(redacted)
+            last_cmp = cmp
+    return ContextBundle(incident=incident, events=events)
+
+
+__all__ = ["build_context"]

--- a/addons/ha-llm-ops/agent/analysis/storage.py
+++ b/addons/ha-llm-ops/agent/analysis/storage.py
@@ -1,0 +1,64 @@
+"""Utilities for loading incident references from disk."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .types import IncidentRef
+
+
+def _parse_time(value: str) -> datetime | None:
+    """Parse an ISO formatted timestamp to ``datetime``.
+
+    Returns ``None`` if the timestamp is invalid.
+    """
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def list_incidents(
+    directory: Path | str = Path("/data/incidents"),
+) -> list[IncidentRef]:
+    """Return ``IncidentRef`` objects for incident files in ``directory``.
+
+    Each incident file is expected to be a JSONL file where each line contains a
+    ``time_fired`` field. Malformed lines are ignored. Files without any valid
+    timestamps are skipped.
+    """
+
+    if isinstance(directory, str):
+        directory = Path(directory)
+    refs: list[IncidentRef] = []
+    for path in sorted(directory.glob("incidents_*.jsonl")):
+        start: datetime | None = None
+        end: datetime | None = None
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:
+            continue
+        for line in lines:
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = data.get("time_fired")
+            if not isinstance(ts, str):
+                continue
+            parsed = _parse_time(ts)
+            if parsed is None:
+                continue
+            if start is None or parsed < start:
+                start = parsed
+            if end is None or parsed > end:
+                end = parsed
+        if start is not None and end is not None:
+            refs.append(IncidentRef(path, start, end))
+    return refs
+
+
+__all__ = ["list_incidents"]

--- a/addons/ha-llm-ops/agent/analysis/types.py
+++ b/addons/ha-llm-ops/agent/analysis/types.py
@@ -1,0 +1,41 @@
+"""Typed structures for analysis pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ..contracts import RcaResult
+
+# Public alias for downstream modules.
+RcaOutput = RcaResult
+
+
+@dataclass(slots=True, frozen=True)
+class IncidentRef:
+    """Reference to an incident file and its time span."""
+
+    path: Path
+    start: datetime
+    end: datetime
+
+
+@dataclass(slots=True, frozen=True)
+class ContextBundle:
+    """Collection of events associated with an incident."""
+
+    incident: IncidentRef
+    events: list[dict[str, Any]]
+
+
+@dataclass(slots=True, frozen=True)
+class Prompt:
+    """Prompt text and JSON schema to send to an LLM."""
+
+    text: str
+    schema: dict[str, Any]
+
+
+__all__ = ["IncidentRef", "ContextBundle", "Prompt", "RcaOutput"]

--- a/tests/test_analysis_context.py
+++ b/tests/test_analysis_context.py
@@ -1,0 +1,42 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from agent.analysis.context import build_context
+from agent.analysis.types import IncidentRef
+
+
+def _evt(event_type: str, **data: object) -> str:
+    return json.dumps({"event_type": event_type, **data})
+
+
+def test_build_context_redaction_and_dedupe(tmp_path: Path) -> None:
+    file = tmp_path / "incidents.jsonl"
+    lines = [
+        _evt("log", time_fired="2024-01-01T00:00:00+00:00", api_key="secret"),
+        _evt("log", time_fired="2024-01-01T00:00:01+00:00", api_key="secret"),
+        _evt("state", time_fired="2024-01-01T00:00:02+00:00"),
+    ]
+    file.write_text("\n".join(lines), encoding="utf-8")
+    secrets = tmp_path / "secrets.yaml"
+    secrets.write_text("api_key: secret\n")
+
+    ref = IncidentRef(file, datetime(2024, 1, 1), datetime(2024, 1, 1, 0, 0, 2))
+    bundle = build_context(ref, max_lines=10, secrets_path=secrets)
+
+    assert len(bundle.events) == 2  # duplicate removed
+    assert bundle.events[0]["api_key"] == "[redacted]"
+
+
+def test_build_context_respects_limit(tmp_path: Path) -> None:
+    file = tmp_path / "incidents.jsonl"
+    lines = [
+        _evt("a", time_fired="2024-01-01T00:00:00+00:00"),
+        _evt("b", time_fired="2024-01-01T00:00:01+00:00"),
+        _evt("c", time_fired="2024-01-01T00:00:02+00:00"),
+    ]
+    file.write_text("\n".join(lines), encoding="utf-8")
+    ref = IncidentRef(file, datetime(2024, 1, 1), datetime(2024, 1, 1, 0, 0, 2))
+
+    bundle = build_context(ref, max_lines=2)
+    assert [e["event_type"] for e in bundle.events] == ["b", "c"]

--- a/tests/test_analysis_storage.py
+++ b/tests/test_analysis_storage.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from agent.analysis.storage import list_incidents
+
+
+def _line(ts: str) -> str:
+    return json.dumps({"time_fired": ts})
+
+
+def test_list_incidents_empty(tmp_path: Path) -> None:
+    assert list_incidents(tmp_path) == []
+
+
+def test_list_incidents_multiple(tmp_path: Path) -> None:
+    f1 = tmp_path / "incidents_a.jsonl"
+    f1.write_text(
+        "\n".join(
+            [
+                _line("2024-01-01T00:00:00+00:00"),
+                _line("2024-01-01T01:00:00+00:00"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    f2 = tmp_path / "incidents_b.jsonl"
+    f2.write_text(
+        "\n".join(
+            [
+                _line("2024-01-02T00:00:00+00:00"),
+                "not json",
+                _line("2024-01-02T01:00:00+00:00"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    refs = list_incidents(tmp_path)
+    assert len(refs) == 2
+    names = [r.path.name for r in refs]
+    assert "incidents_a.jsonl" in names and "incidents_b.jsonl" in names
+    r1 = next(r for r in refs if r.path.name == "incidents_a.jsonl")
+    assert r1.start < r1.end
+
+
+def test_list_incidents_malformed_lines(tmp_path: Path) -> None:
+    bad = tmp_path / "incidents_bad.jsonl"
+    bad.write_text('{not json}\n{"time_fired": "not-a-date"}\n', encoding="utf-8")
+    assert list_incidents(tmp_path) == []

--- a/tests/test_analysis_types.py
+++ b/tests/test_analysis_types.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from pathlib import Path
+
+from agent.analysis.types import ContextBundle, IncidentRef, Prompt, RcaOutput
+
+
+def test_incident_ref_constructor() -> None:
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 2)
+    ref = IncidentRef(Path("incidents_1.jsonl"), start, end)
+    assert ref.path.name == "incidents_1.jsonl"
+    assert ref.start == start
+    assert ref.end == end
+
+
+def test_context_bundle() -> None:
+    ref = IncidentRef(Path("file"), datetime(2024, 1, 1), datetime(2024, 1, 1, 0, 1))
+    bundle = ContextBundle(incident=ref, events=[{"event_type": "x"}])
+    assert bundle.incident == ref
+    assert bundle.events[0]["event_type"] == "x"
+
+
+def test_prompt_and_rca_output_alias() -> None:
+    prompt = Prompt(text="hello", schema={"type": "object"})
+    assert "type" in prompt.schema
+    assert RcaOutput.__name__ == "RcaResult"


### PR DESCRIPTION
## Summary
- scaffold analysis package with typed structures and incident context helpers
- load incident metadata and build redacted context bundles
- add unit tests covering types, storage, and context building

## Testing
- `pytest -m "not integration"`
- `make lint`
- `pre-commit run --files addons/ha-llm-ops/agent/analysis/__init__.py addons/ha-llm-ops/agent/analysis/types.py addons/ha-llm-ops/agent/analysis/storage.py addons/ha-llm-ops/agent/analysis/context.py tests/test_analysis_context.py tests/test_analysis_storage.py tests/test_analysis_types.py` *(fails: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e4a872494832798e18cf0865c1f26