### PR TITLE
Add deterministic prompt builder with golden tests

### DIFF
--- a/addons/ha-llm-ops/agent/analysis/prompt_builder.py
+++ b/addons/ha-llm-ops/agent/analysis/prompt_builder.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from .types import ContextBundle, Prompt, RcaOutput
 
-
 _GUARDRAILS = (
     "You are a Home Assistant diagnostics agent. "
     "Respond only with JSON matching the provided schema. "
@@ -17,12 +16,12 @@ _GUARDRAILS = (
 
 
 def _package_version() -> str:
-    """Return the installed package version or ``unknown``."""
+    """Return the installed package version or ``0.0.0``."""
 
     try:
         return metadata.version("solidha-agent")
     except metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
-        return "unknown"
+        return "0.0.0"
 
 
 def build_prompt(bundle: ContextBundle) -> Prompt:

--- a/addons/ha-llm-ops/agent/analysis/prompt_builder.py
+++ b/addons/ha-llm-ops/agent/analysis/prompt_builder.py
@@ -1,0 +1,58 @@
+"""Build deterministic prompts for RCA analysis."""
+
+from __future__ import annotations
+
+import json
+from importlib import metadata
+from typing import Any
+
+from .types import ContextBundle, Prompt, RcaOutput
+
+
+_GUARDRAILS = (
+    "You are a Home Assistant diagnostics agent. "
+    "Respond only with JSON matching the provided schema. "
+    "Do not include explanations or commentary."
+)
+
+
+def _package_version() -> str:
+    """Return the installed package version or ``unknown``."""
+
+    try:
+        return metadata.version("solidha-agent")
+    except metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
+        return "unknown"
+
+
+def build_prompt(bundle: ContextBundle) -> Prompt:
+    """Return a deterministic prompt for ``bundle``.
+
+    The prompt text contains repository/version info, guardrails and the
+    incident context. The JSON schema is returned separately to allow
+    programmatic validation of LLM responses.
+    """
+
+    schema: dict[str, Any] = RcaOutput.model_json_schema()
+    schema_text = json.dumps(schema, indent=2, sort_keys=True)
+
+    incident_info = {
+        "path": str(bundle.incident.path),
+        "start": bundle.incident.start.isoformat(),
+        "end": bundle.incident.end.isoformat(),
+    }
+    context = {"incident": incident_info, "events": bundle.events}
+    context_text = json.dumps(context, indent=2, sort_keys=True)
+
+    version = _package_version()
+    header = f"SolidHA v{version}\n{_GUARDRAILS}\n\n"
+
+    text = (
+        f"{header}"
+        f"Schema:\n{schema_text}\n\n"
+        f"Context:\n{context_text}\n"
+    )
+    return Prompt(text=text, schema=schema)
+
+
+__all__ = ["build_prompt"]

--- a/tests/golden/prompt_input.json
+++ b/tests/golden/prompt_input.json
@@ -1,0 +1,10 @@
+{
+  "incident": {
+    "path": "incident.log",
+    "start": "2024-01-01T00:00:00",
+    "end": "2024-01-01T00:01:00"
+  },
+  "events": [
+    {"event_type": "system_log_event", "message": "boom"}
+  ]
+}

--- a/tests/golden/prompt_output.txt
+++ b/tests/golden/prompt_output.txt
@@ -1,0 +1,93 @@
+SolidHA v0.0.0
+You are a Home Assistant diagnostics agent. Respond only with JSON matching the provided schema. Do not include explanations or commentary.
+
+Schema:
+{
+  "$defs": {
+    "CandidateAction": {
+      "description": "A potential action to mitigate the incident.",
+      "properties": {
+        "action": {
+          "description": "Short description of the action",
+          "title": "Action",
+          "type": "string"
+        },
+        "rationale": {
+          "description": "Why the action may help",
+          "title": "Rationale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action",
+        "rationale"
+      ],
+      "title": "CandidateAction",
+      "type": "object"
+    }
+  },
+  "description": "LLM-provided root cause analysis result.",
+  "properties": {
+    "candidate_actions": {
+      "description": "Proposed remediation steps",
+      "items": {
+        "$ref": "#/$defs/CandidateAction"
+      },
+      "title": "Candidate Actions",
+      "type": "array"
+    },
+    "confidence": {
+      "description": "Confidence score between 0 and 1",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "impact": {
+      "description": "Observed impact on the system",
+      "title": "Impact",
+      "type": "string"
+    },
+    "risk": {
+      "description": "Overall risk assessment of acting",
+      "title": "Risk",
+      "type": "string"
+    },
+    "root_cause": {
+      "description": "Primary reason for the incident",
+      "title": "Root Cause",
+      "type": "string"
+    },
+    "tests": {
+      "description": "Checks to verify the issue is resolved",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tests",
+      "type": "array"
+    }
+  },
+  "required": [
+    "root_cause",
+    "impact",
+    "confidence",
+    "risk"
+  ],
+  "title": "RcaResult",
+  "type": "object"
+}
+
+Context:
+{
+  "events": [
+    {
+      "event_type": "system_log_event",
+      "message": "boom"
+    }
+  ],
+  "incident": {
+    "end": "2024-01-01T00:01:00",
+    "path": "incident.log",
+    "start": "2024-01-01T00:00:00"
+  }
+}

--- a/tests/test_analysis_prompt_builder.py
+++ b/tests/test_analysis_prompt_builder.py
@@ -1,0 +1,22 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from agent.analysis.prompt_builder import build_prompt
+from agent.analysis.types import ContextBundle, IncidentRef
+
+
+def test_prompt_builder_golden() -> None:
+    data = json.loads(Path("tests/golden/prompt_input.json").read_text())
+    inc = data["incident"]
+    bundle = ContextBundle(
+        incident=IncidentRef(
+            path=Path(inc["path"]),
+            start=datetime.fromisoformat(inc["start"]),
+            end=datetime.fromisoformat(inc["end"]),
+        ),
+        events=data["events"],
+    )
+    prompt = build_prompt(bundle)
+    expected = Path("tests/golden/prompt_output.txt").read_text()
+    assert prompt.text == expected

--- a/tests/update_prompt_snapshot.py
+++ b/tests/update_prompt_snapshot.py
@@ -1,0 +1,29 @@
+"""Utility to regenerate the prompt builder golden file."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from agent.analysis.prompt_builder import build_prompt
+from agent.analysis.types import ContextBundle, IncidentRef
+
+
+def main() -> None:  # pragma: no cover - manual utility
+    data = json.loads(Path("tests/golden/prompt_input.json").read_text())
+    inc = data["incident"]
+    bundle = ContextBundle(
+        incident=IncidentRef(
+            path=Path(inc["path"]),
+            start=datetime.fromisoformat(inc["start"]),
+            end=datetime.fromisoformat(inc["end"]),
+        ),
+        events=data["events"],
+    )
+    prompt = build_prompt(bundle)
+    Path("tests/golden/prompt_output.txt").write_text(prompt.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement prompt builder combining repo version, guardrails, and context to produce deterministic RCA prompt
- add golden files and snapshot test for prompt building
- provide utility script to regenerate prompt snapshot

## Testing
- `pytest`
- `pre-commit run --files addons/ha-llm-ops/agent/analysis/prompt_builder.py tests/test_analysis_prompt_builder.py tests/update_prompt_snapshot.py` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e53972858832799c82560fd029c8e