### PR TITLE
Add LLM adapters and response parser

### DIFF
--- a/addons/ha-llm-ops/agent/analysis/llm/__init__.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/__init__.py
@@ -1,0 +1,7 @@
+"""LLM adapter implementations."""
+
+from .base import LLM
+from .mock import MockLLM
+from .openai import OpenAI
+
+__all__ = ["LLM", "MockLLM", "OpenAI"]

--- a/addons/ha-llm-ops/agent/analysis/llm/base.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/base.py
@@ -1,0 +1,15 @@
+"""Base protocol for LLM adapters."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class LLM(Protocol):
+    """Interface for large language models."""
+
+    def generate(self, prompt: str, *, timeout: float) -> str:
+        """Return a response for ``prompt`` within ``timeout`` seconds."""
+
+
+__all__ = ["LLM"]

--- a/addons/ha-llm-ops/agent/analysis/llm/mock.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/mock.py
@@ -1,0 +1,30 @@
+"""Deterministic mock LLM for tests."""
+
+from __future__ import annotations
+
+import json
+
+from .base import LLM
+
+_RESPONSE = {
+    "root_cause": "mock root cause",
+    "impact": "mock impact",
+    "confidence": 0.42,
+    "candidate_actions": [
+        {"action": "mock action", "rationale": "because tests"}
+    ],
+    "risk": "low",
+    "tests": ["test check"],
+}
+
+
+class MockLLM(LLM):
+    """LLM returning a canned response regardless of input."""
+
+    def generate(self, prompt: str, *, timeout: float) -> str:  # noqa: D401
+        """Return canned ``RcaResult`` JSON ignoring ``prompt`` and ``timeout``."""
+
+        return json.dumps(_RESPONSE)
+
+
+__all__ = ["MockLLM"]

--- a/addons/ha-llm-ops/agent/analysis/llm/openai.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/openai.py
@@ -1,0 +1,46 @@
+"""OpenAI Chat API adapter."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+from .base import LLM
+
+_SYSTEM_PROMPT = "Respond with **only** valid JSON per schema below; no prose."
+_API_URL = "https://api.openai.com/v1/chat/completions"
+
+
+class OpenAI(LLM):
+    """LLM adapter using OpenAI's chat completion endpoint."""
+
+    def __init__(
+        self, model: str = "gpt-3.5-turbo", *, api_key: str | None = None
+    ) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise RuntimeError("OPENAI_API_KEY is not set")
+        self.model = model
+
+    def generate(self, prompt: str, *, timeout: float) -> str:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0,
+        }
+        resp = requests.post(_API_URL, headers=headers, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"]
+
+
+__all__ = ["OpenAI"]

--- a/addons/ha-llm-ops/agent/analysis/parse.py
+++ b/addons/ha-llm-ops/agent/analysis/parse.py
@@ -1,0 +1,29 @@
+"""Parsing utilities for LLM responses."""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import ValidationError
+
+from .types import RcaOutput
+
+
+class ParseError(ValueError):
+    """Raised when an LLM response cannot be parsed."""
+
+
+def parse_result(text: str) -> RcaOutput:
+    """Parse ``text`` into an ``RcaOutput`` instance."""
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ParseError("LLM response is not valid JSON") from exc
+    try:
+        return RcaOutput.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - defensive
+        raise ParseError("LLM response does not match schema") from exc
+
+
+__all__ = ["ParseError", "parse_result"]

--- a/tests/test_analysis_llm_openai.py
+++ b/tests/test_analysis_llm_openai.py
@@ -1,0 +1,41 @@
+import pytest
+
+from agent.analysis.llm import openai
+
+
+def test_openai_requires_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        openai.OpenAI()
+
+
+def test_openai_generate(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+
+    captured = {}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.update(
+            {"url": url, "headers": headers, "json": json, "timeout": timeout}
+        )
+
+        class Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"choices": [{"message": {"content": "{}"}}]}
+
+        return Resp()
+
+    monkeypatch.setattr(openai.requests, "post", fake_post)
+
+    llm = openai.OpenAI()
+    result = llm.generate("prompt", timeout=2.5)
+
+    assert result == "{}"
+    assert captured["timeout"] == 2.5
+    assert captured["headers"]["Authorization"] == "Bearer token"
+    messages = captured["json"]["messages"]
+    assert messages[0]["content"] == openai._SYSTEM_PROMPT
+    assert messages[1]["content"] == "prompt"

--- a/tests/test_analysis_parse.py
+++ b/tests/test_analysis_parse.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from agent.analysis.llm.mock import MockLLM
+from agent.analysis.parse import ParseError, parse_result
+
+
+def test_parse_valid() -> None:
+    llm = MockLLM()
+    text = llm.generate("prompt", timeout=1)
+    result = parse_result(text)
+    assert result.root_cause == "mock root cause"
+
+
+def test_parse_invalid_json() -> None:
+    with pytest.raises(ParseError):
+        parse_result("not json")
+
+
+def test_parse_invalid_schema() -> None:
+    bad = json.dumps({"impact": "x"})
+    with pytest.raises(ParseError):
+        parse_result(bad)


### PR DESCRIPTION
## Summary
- add LLM protocol and mock adapter
- implement OpenAI chat adapter reading `OPENAI_API_KEY`
- add strict parser for LLM JSON responses and unit tests

## Testing
- `ruff check agent/analysis/llm/openai.py tests/test_analysis_llm_openai.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f089c82ec8327a11b432f6291b80f