### PR TITLE
Add analysis runner and expose analyses endpoint

### DIFF
--- a/addons/ha-llm-ops/agent/__main__.py
+++ b/addons/ha-llm-ops/agent/__main__.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 from pathlib import Path
 
+from .analysis.runner import AnalysisRunner, create_llm
 from .devux import start_http_server
 from .observability import observe
 
@@ -17,6 +19,10 @@ def main() -> None:
     logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
     buffer_size = os.environ.get("BUFFER_SIZE", "100")
     incident_dir = os.environ.get("INCIDENT_DIR", "/data/incidents")
+    analysis_dir = Path("/data/analyses")
+    rate = float(os.environ.get("ANALYSIS_RATE_SECONDS", "60"))
+    max_lines = int(os.environ.get("ANALYSIS_MAX_LINES", "50"))
+    backend = os.environ.get("LLM_BACKEND")
     ws_url = os.environ.get("HA_WS_URL", "ws://localhost:8123/api/websocket")
     token = os.environ.get("SUPERVISOR_TOKEN", "")
     logging.info(
@@ -27,8 +33,22 @@ def main() -> None:
         ws_url,
     )
     Path("/tmp/healthy").touch()
-    start_http_server(Path(incident_dir))
-    asyncio.run(observe(ws_url, token, Path(incident_dir)))
+    start_http_server(Path(incident_dir), analysis_dir=analysis_dir)
+    llm = create_llm(backend)
+    runner = AnalysisRunner(
+        Path(incident_dir), analysis_dir, llm, rate_seconds=rate, max_lines=max_lines
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(runner.run_forever())
+        try:
+            await observe(ws_url, token, Path(incident_dir))
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":  # pragma: no cover - manual entry

--- a/addons/ha-llm-ops/agent/analysis/runner.py
+++ b/addons/ha-llm-ops/agent/analysis/runner.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import Any, TextIO
 
 from .context import build_context
 from .llm.base import LLM
@@ -27,15 +28,15 @@ class AnalysisLogger:
         self.max_bytes = max_bytes
         self.directory.mkdir(parents=True, exist_ok=True)
         self._counter = 0
-        self._file = self._open_file()
+        self._file: TextIO = self._open_file()
 
-    def _open_file(self):
+    def _open_file(self) -> TextIO:
         timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
         path = self.directory / f"analyses_{timestamp}_{self._counter}.jsonl"
         self._counter += 1
         return path.open("a", encoding="utf-8")
 
-    def write(self, record: dict) -> None:
+    def write(self, record: dict[str, Any]) -> None:
         line = json.dumps(record, sort_keys=True)
         if self._file.tell() + len(line) + 1 > self.max_bytes:
             self._file.close()

--- a/addons/ha-llm-ops/agent/analysis/runner.py
+++ b/addons/ha-llm-ops/agent/analysis/runner.py
@@ -5,9 +5,9 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
 
 from .context import build_context
 from .llm.base import LLM

--- a/addons/ha-llm-ops/agent/analysis/runner.py
+++ b/addons/ha-llm-ops/agent/analysis/runner.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+from .context import build_context
+from .llm.base import LLM
+from .llm.mock import MockLLM
+from .llm.openai import OpenAI
+from .parse import parse_result
+from .prompt_builder import build_prompt
+from .storage import list_incidents
+from .types import IncidentRef
+
+
+class AnalysisLogger:
+    """Write analysis results to rotating JSONL files."""
+
+    def __init__(self, directory: Path, max_bytes: int = 1_000_000) -> None:
+        self.directory = directory
+        self.max_bytes = max_bytes
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._counter = 0
+        self._file = self._open_file()
+
+    def _open_file(self):
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        path = self.directory / f"analyses_{timestamp}_{self._counter}.jsonl"
+        self._counter += 1
+        return path.open("a", encoding="utf-8")
+
+    def write(self, record: dict) -> None:
+        line = json.dumps(record, sort_keys=True)
+        if self._file.tell() + len(line) + 1 > self.max_bytes:
+            self._file.close()
+            self._file = self._open_file()
+        self._file.write(line + "\n")
+        self._file.flush()
+
+
+def create_llm(backend: str | None = None) -> LLM:
+    """Return an ``LLM`` instance based on ``backend`` or environment."""
+
+    if backend is None:
+        backend = "OPENAI" if os.getenv("OPENAI_API_KEY") else "MOCK"
+    backend = backend.upper()
+    if backend == "OPENAI":
+        return OpenAI()
+    return MockLLM()
+
+
+class AnalysisRunner:
+    """Periodic incident analyzer writing results to disk."""
+
+    def __init__(
+        self,
+        incident_dir: Path,
+        analysis_dir: Path,
+        llm: LLM,
+        *,
+        rate_seconds: float = 60.0,
+        max_lines: int = 50,
+        max_bytes: int = 1_000_000,
+        now_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.incident_dir = incident_dir
+        self.llm = llm
+        self.rate_seconds = rate_seconds
+        self.max_lines = max_lines
+        self._now = now_fn
+        self._next_run = 0.0
+        self._backoff = 1.0
+        self._processed: set[Path] = set()
+        self.logger = AnalysisLogger(analysis_dir, max_bytes=max_bytes)
+
+    def _analyze(self, incident: IncidentRef) -> None:
+        bundle = build_context(incident, max_lines=self.max_lines)
+        prompt = build_prompt(bundle)
+        raw = self.llm.generate(prompt.text, timeout=30)
+        result = parse_result(raw)
+        record = {"incident": str(incident.path), "result": result.model_dump()}
+        self.logger.write(record)
+
+    def run_once(self) -> None:
+        now = self._now()
+        if now < self._next_run:
+            return
+        incidents = list_incidents(self.incident_dir)
+        try:
+            for inc in incidents:
+                if inc.path in self._processed:
+                    continue
+                self._analyze(inc)
+                self._processed.add(inc.path)
+        except Exception:  # pragma: no cover - defensive
+            logging.exception("analysis failed")
+            self._next_run = now + self._backoff
+            self._backoff = min(self._backoff * 2, 60)
+            return
+        self._next_run = now + self.rate_seconds
+        self._backoff = 1.0
+
+    async def run_forever(self) -> None:
+        while True:
+            self.run_once()
+            await asyncio.sleep(max(self._next_run - self._now(), 0))
+
+
+__all__ = ["AnalysisRunner", "create_llm"]

--- a/tests/test_agent_main_runner.py
+++ b/tests/test_agent_main_runner.py
@@ -1,0 +1,35 @@
+import asyncio
+from pathlib import Path
+
+import agent.__main__ as agent_main
+from agent.analysis.llm.mock import MockLLM
+
+
+def test_main_starts_runner(monkeypatch, tmp_path: Path) -> None:
+    called = {"runner": False, "observe": False}
+
+    class DummyRunner:
+        def __init__(self, *a, **k):
+            pass
+
+        async def run_forever(self):
+            called["runner"] = True
+            await asyncio.sleep(0)
+
+    async def fake_observe(*args, **kwargs):
+        called["observe"] = True
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(agent_main, "AnalysisRunner", DummyRunner)
+    monkeypatch.setattr(agent_main, "observe", fake_observe)
+    monkeypatch.setattr(agent_main, "start_http_server", lambda *a, **k: None)
+    monkeypatch.setattr(agent_main, "create_llm", lambda backend: MockLLM())
+
+    monkeypatch.setenv("INCIDENT_DIR", str(tmp_path))
+    monkeypatch.setenv("HA_WS_URL", "ws://test")
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+
+    agent_main.main()
+
+    assert called["runner"]
+    assert called["observe"]

--- a/tests/test_analysis_runner.py
+++ b/tests/test_analysis_runner.py
@@ -17,7 +17,14 @@ def test_runner_processes_new_incidents(tmp_path: Path) -> None:
 
     _incident(inc_dir / "incidents_1.jsonl", "2024-01-01T00:00:00+00:00")
 
-    runner = AnalysisRunner(inc_dir, out_dir, MockLLM(), rate_seconds=0, max_lines=5, max_bytes=1000)
+    runner = AnalysisRunner(
+        inc_dir,
+        out_dir,
+        MockLLM(),
+        rate_seconds=0,
+        max_lines=5,
+        max_bytes=1000,
+    )
     runner.run_once()
 
     files = sorted(out_dir.glob("analyses_*.jsonl"))
@@ -30,7 +37,10 @@ def test_runner_processes_new_incidents(tmp_path: Path) -> None:
     lines = files[0].read_text().splitlines()
     assert len(lines) == 2
     data = [json.loads(line)["incident"] for line in lines]
-    assert data == [str(inc_dir / "incidents_1.jsonl"), str(inc_dir / "incidents_2.jsonl")]
+    assert data == [
+        str(inc_dir / "incidents_1.jsonl"),
+        str(inc_dir / "incidents_2.jsonl"),
+    ]
 
 
 def test_runner_rate_limit(tmp_path: Path) -> None:
@@ -84,7 +94,14 @@ def test_runner_rotation(tmp_path: Path) -> None:
     inc_dir.mkdir()
     out_dir.mkdir()
 
-    runner = AnalysisRunner(inc_dir, out_dir, MockLLM(), rate_seconds=0, max_lines=5, max_bytes=80)
+    runner = AnalysisRunner(
+        inc_dir,
+        out_dir,
+        MockLLM(),
+        rate_seconds=0,
+        max_lines=5,
+        max_bytes=80,
+    )
 
     for i in range(5):
         _incident(inc_dir / f"incidents_{i}.jsonl", f"2024-01-01T00:00:0{i}+00:00")

--- a/tests/test_analysis_runner.py
+++ b/tests/test_analysis_runner.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+from agent.analysis.llm.mock import MockLLM
+from agent.analysis.runner import AnalysisRunner
+
+
+def _incident(path: Path, ts: str) -> None:
+    path.write_text(f'{{"time_fired":"{ts}"}}\n', encoding="utf-8")
+
+
+def test_runner_processes_new_incidents(tmp_path: Path) -> None:
+    inc_dir = tmp_path / "inc"
+    out_dir = tmp_path / "out"
+    inc_dir.mkdir()
+    out_dir.mkdir()
+
+    _incident(inc_dir / "incidents_1.jsonl", "2024-01-01T00:00:00+00:00")
+
+    runner = AnalysisRunner(inc_dir, out_dir, MockLLM(), rate_seconds=0, max_lines=5, max_bytes=1000)
+    runner.run_once()
+
+    files = sorted(out_dir.glob("analyses_*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().splitlines()
+    assert len(lines) == 1
+
+    _incident(inc_dir / "incidents_2.jsonl", "2024-01-01T00:00:01+00:00")
+    runner.run_once()
+    lines = files[0].read_text().splitlines()
+    assert len(lines) == 2
+    data = [json.loads(line)["incident"] for line in lines]
+    assert data == [str(inc_dir / "incidents_1.jsonl"), str(inc_dir / "incidents_2.jsonl")]
+
+
+def test_runner_rate_limit(tmp_path: Path) -> None:
+    inc_dir = tmp_path / "inc"
+    out_dir = tmp_path / "out"
+    inc_dir.mkdir()
+    out_dir.mkdir()
+
+    _incident(inc_dir / "incidents_1.jsonl", "2024-01-01T00:00:00+00:00")
+
+    current = 0.0
+
+    def now() -> float:
+        return current
+
+    llm = MockLLM()
+    count = {"c": 0}
+    orig = llm.generate
+
+    def gen(prompt: str, *, timeout: float) -> str:
+        count["c"] += 1
+        return orig(prompt, timeout=timeout)
+
+    llm.generate = gen  # type: ignore[assignment]
+
+    runner = AnalysisRunner(
+        inc_dir,
+        out_dir,
+        llm,
+        rate_seconds=10,
+        max_lines=5,
+        max_bytes=1000,
+        now_fn=now,
+    )
+
+    runner.run_once()
+    assert count["c"] == 1
+
+    _incident(inc_dir / "incidents_2.jsonl", "2024-01-01T00:00:01+00:00")
+    runner.run_once()
+    assert count["c"] == 1  # skipped due to rate limit
+
+    current = 11
+    runner.run_once()
+    assert count["c"] == 2
+
+
+def test_runner_rotation(tmp_path: Path) -> None:
+    inc_dir = tmp_path / "inc"
+    out_dir = tmp_path / "out"
+    inc_dir.mkdir()
+    out_dir.mkdir()
+
+    runner = AnalysisRunner(inc_dir, out_dir, MockLLM(), rate_seconds=0, max_lines=5, max_bytes=80)
+
+    for i in range(5):
+        _incident(inc_dir / f"incidents_{i}.jsonl", f"2024-01-01T00:00:0{i}+00:00")
+        runner.run_once()
+
+    files = sorted(out_dir.glob("analyses_*.jsonl"))
+    assert len(files) >= 2
+    total = sum(len(f.read_text().splitlines()) for f in files)
+    assert total == 5

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -1,5 +1,6 @@
 import time
 from pathlib import Path
+
 import requests
 
 from agent.devux import start_http_server
@@ -22,7 +23,12 @@ def test_http_lists_incident_files(tmp_path: Path) -> None:
 
 def test_http_lists_analysis_files(tmp_path: Path) -> None:
     (tmp_path / "analyses_1.jsonl").write_text("{}\n", encoding="utf-8")
-    server = start_http_server(tmp_path, analysis_dir=tmp_path, host="127.0.0.1", port=0)
+    server = start_http_server(
+        tmp_path,
+        analysis_dir=tmp_path,
+        host="127.0.0.1",
+        port=0,
+    )
     try:
         time.sleep(0.1)
         port = server.server_address[1]
@@ -34,7 +40,12 @@ def test_http_lists_analysis_files(tmp_path: Path) -> None:
 
 
 def test_http_analyses_empty(tmp_path: Path) -> None:
-    server = start_http_server(tmp_path, analysis_dir=tmp_path, host="127.0.0.1", port=0)
+    server = start_http_server(
+        tmp_path,
+        analysis_dir=tmp_path,
+        host="127.0.0.1",
+        port=0,
+    )
     try:
         time.sleep(0.1)
         port = server.server_address[1]

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -1,6 +1,5 @@
 import time
 from pathlib import Path
-
 import requests
 
 from agent.devux import start_http_server
@@ -17,5 +16,41 @@ def test_http_lists_incident_files(tmp_path: Path) -> None:
         resp = requests.get(f"http://127.0.0.1:{port}/incidents", timeout=5)
         assert resp.status_code == 200
         assert resp.json() == ["incidents_1.jsonl", "incidents_2.jsonl"]
+    finally:
+        server.shutdown()
+
+
+def test_http_lists_analysis_files(tmp_path: Path) -> None:
+    (tmp_path / "analyses_1.jsonl").write_text("{}\n", encoding="utf-8")
+    server = start_http_server(tmp_path, analysis_dir=tmp_path, host="127.0.0.1", port=0)
+    try:
+        time.sleep(0.1)
+        port = server.server_address[1]
+        resp = requests.get(f"http://127.0.0.1:{port}/analyses", timeout=5)
+        assert resp.status_code == 200
+        assert resp.json() == ["analyses_1.jsonl"]
+    finally:
+        server.shutdown()
+
+
+def test_http_analyses_empty(tmp_path: Path) -> None:
+    server = start_http_server(tmp_path, analysis_dir=tmp_path, host="127.0.0.1", port=0)
+    try:
+        time.sleep(0.1)
+        port = server.server_address[1]
+        resp = requests.get(f"http://127.0.0.1:{port}/analyses", timeout=5)
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        server.shutdown()
+
+
+def test_http_analyses_404(tmp_path: Path) -> None:
+    server = start_http_server(tmp_path, host="127.0.0.1", port=0)
+    try:
+        time.sleep(0.1)
+        port = server.server_address[1]
+        resp = requests.get(f"http://127.0.0.1:{port}/analyses", timeout=5)
+        assert resp.status_code == 404
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- add analysis runner with pluggable LLM and JSONL storage
- expose `/analyses` listing in dev HTTP server
- wire analysis runner into agent entrypoint and add tests

## Testing
- `pytest`
- `pre-commit run --files agent/devux.py agent/analysis/runner.py agent/__main__.py tests/test_devux.py tests/test_analysis_runner.py tests/test_agent_main_runner.py` *(fails: RPC failed; HTTP 403 curl 22)*

------
https://chatgpt.com/codex/tasks/task_e_689f0d9da3ac8327937d1a18cbe5286c