### PR TITLE
ci: upload coverage to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           python-version: '3.11'
       - run: pip install .[dev]
       - run: pytest --cov=agent --cov-report=xml
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-xml


### PR DESCRIPTION
## Summary
- upload coverage results to Codecov via GitHub Action

## Testing
- `pytest --cov=agent --cov-report=xml`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f14f02c1083279e638e8cd6c63f93