### PR TITLE
docs: add minimal analyses UI and guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,43 @@
 # Documentation
 
-Placeholder for project documentation.
+## User guide
+
+The agent exposes a tiny HTTP server that serves incident and analysis
+information.  When running locally it binds to `http://localhost:8000` and
+offers two read‑only endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/incidents` | List of incident bundle filenames. |
+| `/analyses`  | List of analysis bundle filenames, newest first. |
+
+### Choosing an LLM backend
+
+The analysis runner supports either a deterministic mock model (useful for
+development and tests) or the OpenAI API:
+
+- **Mock LLM** – default, no network traffic.  Set `LLM_BACKEND=MOCK`.
+- **OpenAI** – real calls to OpenAI's API.  Set `LLM_BACKEND=OPENAI` and provide
+  `OPENAI_API_KEY` in the environment.
+
+Additional environment variables control analysis behaviour:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `ANALYSIS_RATE_SECONDS` | How often the runner scans for new incidents. | `300` |
+| `ANALYSIS_MAX_LINES` | Maximum lines read from each incident bundle. | `2000` |
+
+### Sample flow (mock LLM)
+
+1. Start the agent with `LLM_BACKEND=MOCK`.
+2. Drop a JSONL incident file into `/data/incidents`.
+3. After the next scan a corresponding analysis file appears under
+   `/data/analyses` and `/analyses` will list it.
+4. Use the example Lovelace card to visualise recent analyses in Home Assistant.
+
+## Developer notes
+
+- Set `LLM_BACKEND=MOCK` to run tests without network access.
+- Real LLM tests are only executed when `OPENAI_API_KEY` is defined.
+- Run `make pre-commit` before committing to execute linters and tests.
+

--- a/docs/example_lovelace_card.yaml
+++ b/docs/example_lovelace_card.yaml
@@ -1,18 +1,24 @@
-# Example Lovelace setup polling the agent's incident endpoint.
+# Example Lovelace card showing recent analyses from the agent.
 #
-# Define a REST sensor in configuration.yaml:
+# Define a REST sensor in ``configuration.yaml``:
+#
 # sensor:
 #   - platform: rest
-#     name: incident_bundles
-#     resource: http://localhost:8000/incidents
+#     name: agent_analyses
+#     resource: http://localhost:8000/analyses
 #     scan_interval: 30
+#     value_template: "{{ value_json | tojson }}"
 #
-# Then add this card to your dashboard:
+# Then add this card to your dashboard to browse analyses.  The card lists
+# newest files first and clicking an entry reveals the parsed ``RcaResult``.
 type: markdown
-title: Agent Incidents
+title: Agent Analyses
 content: |
-  {% set incidents = states('sensor.incident_bundles') | from_json %}
-  {% for inc in incidents %}
-  - {{ inc }}
+  {% set data = states('sensor.agent_analyses') | from_json %}
+  {% for item in data | sort(reverse=True) %}
+  <details>
+    <summary>{{ item.file }}</summary>
+    <pre>{{ item.result | tojson(indent=2) }}</pre>
+  </details>
   {% endfor %}
 


### PR DESCRIPTION
## Summary
- document LLM backends and analysis endpoints
- provide a Lovelace card example for viewing analysis results

## Testing
- `/root/.pyenv/versions/3.12.10/bin/pre-commit run --all-files` *(fails: HTTP 403 when fetching hooks)*

------
https://chatgpt.com/codex/tasks/task_e_689f1a853ab48327a4d69b31204319c5