### PR TITLE
Add Home Assistant repository metadata

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+# https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
+name: SolidHA Add-on Repository
+url: 'https://github.com/lextiz/SolidHA'
+maintainer: Alexander Bolshakov <1011830+lextiz@users.noreply.github.com>


### PR DESCRIPTION
## Summary
- add `repository.yaml` metadata so HA recognizes this repo as a valid add-on repository

## Testing
- `pre-commit run --files repository.yaml` *(fails: CalledProcessError: git fetch origin 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f29d4c5ec8327a1f0db21c3cb2ea9