### PR TITLE
Handle supervisor WebSocket authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 coverage.*
 *.egg-info/
 .coverage
+build/

--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 from datetime import UTC, datetime
@@ -40,12 +41,28 @@ class IncidentLogger:
 
 
 async def _authenticate(ws: Any, token: str) -> None:
-    """Perform Home Assistant WebSocket authentication."""
+    """Perform Home Assistant WebSocket authentication.
+
+    The HA Supervisor proxies the WebSocket API and authenticates via the
+    ``Authorization`` header rather than an ``access_token`` message. When
+    connecting directly to Home Assistant, an ``access_token`` message is still
+    required.  To support both cases we first try token-based auth and, on
+    failure, retry without the token which allows header-based auth to succeed.
+    """
+
     msg = json.loads(await ws.recv())
     if msg.get("type") != "auth_required":  # pragma: no cover - defensive
         raise RuntimeError("unexpected auth sequence")
+
     await ws.send(json.dumps({"type": "auth", "access_token": token}))
     msg = json.loads(await ws.recv())
+
+    if msg.get("type") == "auth_invalid":
+        # Some environments (e.g. HA Supervisor proxy) authenticate via the
+        # Authorization header and expect an empty auth message.
+        await ws.send(json.dumps({"type": "auth"}))
+        msg = json.loads(await ws.recv())
+
     if msg.get("type") != "auth_ok":  # pragma: no cover - defensive
         raise RuntimeError("authentication failed")
 
@@ -64,9 +81,16 @@ async def observe(
     logger = IncidentLogger(incident_dir, max_bytes=max_bytes)
     backoff = 1
     processed = 0
+
+    headers = {"Authorization": f"Bearer {token}"}
+    kwargs: dict[str, Any] = {}
+    if "extra_headers" in inspect.signature(websockets.connect).parameters:
+        kwargs["extra_headers"] = headers
+    else:
+        kwargs["additional_headers"] = headers
     while True:
         try:
-            async with websockets.connect(url) as ws:
+            async with websockets.connect(url, **kwargs) as ws:
                 await _authenticate(ws, token)
                 await ws.send(json.dumps({"id": 1, "type": "subscribe_events"}))
                 async for message in ws:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -26,6 +26,34 @@ async def _serve(events: list[dict]) -> str:
     return server, f"ws://localhost:{port}"
 
 
+async def _serve_header_auth() -> str:
+    """Server that requires header-based authentication."""
+
+    async def handler(ws):
+        # Ensure we received the Authorization header
+        headers = getattr(ws, "request_headers", None)
+        if headers is None:  # websockets >=15
+            headers = ws.request.headers
+        assert headers["Authorization"] == "Bearer t"
+        await ws.send(json.dumps({"type": "auth_required"}))
+
+        # First auth attempt with token should fail
+        msg = json.loads(await ws.recv())
+        assert msg == {"type": "auth", "access_token": "t"}
+        await ws.send(json.dumps({"type": "auth_invalid"}))
+
+        # Fallback auth without token succeeds
+        msg = json.loads(await ws.recv())
+        assert msg == {"type": "auth"}
+        await ws.send(json.dumps({"type": "auth_ok"}))
+
+        await ws.recv()  # subscribe
+
+    server = await websockets.serve(handler, "localhost", 0)
+    port = server.sockets[0].getsockname()[1]
+    return server, f"ws://localhost:{port}"
+
+
 def test_observe_writes_redacted_events(tmp_path: Path) -> None:
     secrets = tmp_path / "secrets.yaml"
     secrets.write_text("api_key: supersecret\npassword: hidden\n")
@@ -74,13 +102,16 @@ def test_observe_writes_redacted_events(tmp_path: Path) -> None:
     async def run_test() -> None:
         server, url = await _serve(events)
         try:
-            await observe(
-                url,
-                token="t",
-                incident_dir=tmp_path,
-                max_bytes=120,
-                limit=3,
-                secrets_path=secrets,
+            await asyncio.wait_for(
+                observe(
+                    url,
+                    token="t",
+                    incident_dir=tmp_path,
+                    max_bytes=120,
+                    limit=3,
+                    secrets_path=secrets,
+                ),
+                timeout=3,
             )
         finally:
             server.close()
@@ -107,3 +138,26 @@ def test_observe_writes_redacted_events(tmp_path: Path) -> None:
         assert "hidden" not in dumped
         assert "ZZZZYYYY" not in dumped
         assert "[redacted]" in dumped
+
+
+def test_observe_falls_back_to_header_auth(tmp_path: Path) -> None:
+    """Ensure observer retries auth without token when header auth is required."""
+
+    async def run_test() -> None:
+        server, url = await _serve_header_auth()
+        try:
+            await asyncio.wait_for(
+                observe(
+                    url,
+                    token="t",
+                    incident_dir=tmp_path,
+                    limit=0,
+                    secrets_path=tmp_path / "secrets.yaml",
+                ),
+                timeout=1,
+            )
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- allow WebSocket auth to retry without access token when supervisor handles Authorization header
- add test for header-based authentication fallback
- ensure websocket client uses correct header argument across library versions and prevent tests from hanging
- organize imports and ignore build artifacts to satisfy ruff
- use explicit header kwargs so mypy can type-check connection call

## Testing
- `ruff check .`
- `mypy agent`
- `pytest tests/test_observability.py -vv`
- `pre-commit run --files addons/ha-llm-ops/agent/observability.py tests/test_observability.py` *(fails: HTTP 403 fetching hooks)*

------
https://chatgpt.com/codex/tasks/task_e_689f43c666d8832783a79bf638c29fe2