### PR TITLE
Fix WebSocket connection by specifying HA subprotocol

### DIFF
--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -83,7 +83,7 @@ async def observe(
     processed = 0
 
     headers = {"Authorization": f"Bearer {token}"}
-    kwargs: dict[str, Any] = {}
+    kwargs: dict[str, Any] = {"subprotocols": ["homeassistant"]}
     if "extra_headers" in inspect.signature(websockets.connect).parameters:
         kwargs["extra_headers"] = headers
     else:


### PR DESCRIPTION
## Summary
- add required `homeassistant` WebSocket subprotocol when connecting to the HA WebSocket API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f513a380c83278e1859b0e28a8aa4