### PR TITLE
Handle header-based auth first

### DIFF
--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -37,14 +37,14 @@ async def _serve_header_auth() -> str:
         assert headers["Authorization"] == "Bearer t"
         await ws.send(json.dumps({"type": "auth_required"}))
 
-        # First auth attempt with token should fail
-        msg = json.loads(await ws.recv())
-        assert msg == {"type": "auth", "access_token": "t"}
-        await ws.send(json.dumps({"type": "auth_invalid"}))
-
-        # Fallback auth without token succeeds
+        # First auth attempt without token should fail
         msg = json.loads(await ws.recv())
         assert msg == {"type": "auth"}
+        await ws.send(json.dumps({"type": "auth_invalid"}))
+
+        # Fallback auth with token succeeds
+        msg = json.loads(await ws.recv())
+        assert msg == {"type": "auth", "access_token": "t"}
         await ws.send(json.dumps({"type": "auth_ok"}))
 
         await ws.recv()  # subscribe


### PR DESCRIPTION
## Summary
- fix WebSocket authentication for HA Supervisor environments
- update header-auth test to match new handshake

## Testing
- `pre-commit run --files agent/observability.py tests/test_observability.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5bcb05e88327a5e97807b9b842f9