### PR TITLE
Handle HA WebSocket auth header fallback

### DIFF
--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -13,11 +13,11 @@ from typing import Any, TextIO
 import websockets
 from websockets.exceptions import ConnectionClosed
 
+from .redact import load_secret_keys, redact
+
 
 class AuthenticationError(RuntimeError):
     """Raised when Home Assistant authentication fails."""
-
-from .redact import load_secret_keys, redact
 
 
 class IncidentLogger:

--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -13,6 +13,10 @@ from typing import Any, TextIO
 import websockets
 from websockets.exceptions import ConnectionClosed
 
+
+class AuthenticationError(RuntimeError):
+    """Raised when Home Assistant authentication fails."""
+
 from .redact import load_secret_keys, redact
 
 
@@ -58,7 +62,7 @@ async def _authenticate(ws: Any, token: str, *, prefer_header: bool = False) -> 
     messages.append(msg)
     if msg.get("type") != "auth_required":  # pragma: no cover - defensive
         pretty = json.dumps(messages, indent=2)
-        raise RuntimeError(f"unexpected auth sequence: {pretty}")
+        raise AuthenticationError(f"unexpected auth sequence: {pretty}")
 
     if prefer_header:
         await ws.send(json.dumps({"type": "auth"}))
@@ -75,7 +79,7 @@ async def _authenticate(ws: Any, token: str, *, prefer_header: bool = False) -> 
 
     if msg.get("type") != "auth_ok":  # pragma: no cover - defensive
         pretty = json.dumps(messages, indent=2)
-        raise RuntimeError(f"authentication failed: {pretty}")
+        raise AuthenticationError(f"authentication failed: {pretty}")
 
 
 async def observe(
@@ -146,6 +150,13 @@ async def observe(
                     if limit is not None and processed >= limit:
                         return
         except ConnectionClosed as err:  # pragma: no cover - network error path
+            logging.exception("WebSocket error: %s", err)
+            if not prefer_header:
+                prefer_header = True
+                continue
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+        except AuthenticationError as err:  # pragma: no cover - auth error path
             logging.exception("WebSocket error: %s", err)
             if not prefer_header:
                 prefer_header = True

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.6
+version: 0.0.7
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import websockets
 
-from agent.observability import _authenticate, observe
+from agent.observability import AuthenticationError, _authenticate, observe
 
 
 def _event(event_type: str, data: dict) -> dict:
@@ -71,6 +71,39 @@ async def _serve_auth_failure() -> str:
         msg = json.loads(await ws.recv())
         assert msg == {"type": "auth", "access_token": "t"}
         await ws.send(json.dumps({"type": "auth_invalid"}))
+
+    server = await websockets.serve(handler, "localhost", 0)
+    port = server.sockets[0].getsockname()[1]
+    return server, f"ws://localhost:{port}"
+
+
+async def _serve_header_auth_invalid() -> str:
+    """Server that responds with auth_invalid before closing the first attempt."""
+
+    call_count = 0
+
+    async def handler(ws):
+        nonlocal call_count
+        call_count += 1
+        headers = getattr(ws, "request_headers", None)
+        if headers is None:  # websockets >=15
+            headers = ws.request.headers
+        assert headers["Authorization"] == "Bearer t"
+        await ws.send(json.dumps({"type": "auth_required"}))
+        msg = json.loads(await ws.recv())
+        if call_count == 1:
+            assert msg == {"type": "auth", "access_token": "t"}
+            await ws.send(json.dumps({"type": "auth_invalid"}))
+            await ws.close()
+            return
+
+        assert msg == {"type": "auth"}
+        await ws.send(json.dumps({"type": "auth_invalid"}))
+        msg = json.loads(await ws.recv())
+        assert msg == {"type": "auth", "access_token": "t"}
+        await ws.send(json.dumps({"type": "auth_ok"}))
+        await ws.recv()  # subscribe
+        await ws.close()
 
     server = await websockets.serve(handler, "localhost", 0)
     port = server.sockets[0].getsockname()[1]
@@ -186,12 +219,35 @@ def test_observe_falls_back_to_header_auth(tmp_path: Path) -> None:
     asyncio.run(run_test())
 
 
+def test_observe_recovers_from_auth_invalid(tmp_path: Path) -> None:
+    """Ensure observer retries with header auth after auth_invalid message."""
+
+    async def run_test() -> None:
+        server, url = await _serve_header_auth_invalid()
+        try:
+            await asyncio.wait_for(
+                observe(
+                    url,
+                    token="t",
+                    incident_dir=tmp_path,
+                    limit=0,
+                    secrets_path=tmp_path / "secrets.yaml",
+                ),
+                timeout=1,
+            )
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(run_test())
+
+
 def test_auth_failure_includes_details(tmp_path: Path) -> None:
     async def run_test() -> None:
         server, url = await _serve_auth_failure()
         try:
             async with websockets.connect(url, subprotocols=["homeassistant"]) as ws:
-                with pytest.raises(RuntimeError) as ctx:
+                with pytest.raises(AuthenticationError) as ctx:
                     await _authenticate(ws, "t")
                 detail = ctx.value.args[0].split(": ", 1)[1]
                 data = json.loads(detail)


### PR DESCRIPTION
## Summary
- Gracefully retry Home Assistant WebSocket auth using headers when token-based auth fails
- Increase add-on version to 0.0.7

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f672d74e88327b0153d34bdf283aa