### PR TITLE
feat: enhance incident UI and analysis display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS
+
+Run `ruff check .`, `mypy agent`, and `pytest` to validate all code changes before submitting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # AGENTS
 
-Run `ruff check .`, `mypy agent`, and `pytest` to validate all code changes before submitting.
+- Run `ruff check .`, `mypy agent`, and `pytest` to validate all code changes before submitting.
+- Bump version in addons/ha-llm-ops/config.yaml

--- a/addons/ha-llm-ops/agent/analysis/prompt_builder.py
+++ b/addons/ha-llm-ops/agent/analysis/prompt_builder.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from importlib import metadata
+from pathlib import Path
 from typing import Any
 
 from .types import ContextBundle, Prompt, RcaOutput
@@ -21,7 +23,12 @@ def _package_version() -> str:
     try:
         return metadata.version("solidha-agent")
     except metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
-        return "0.0.0"
+        try:
+            pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+            data = tomllib.loads(pyproject.read_text())
+            return str(data["project"]["version"])
+        except Exception:  # pragma: no cover - final fallback
+            return "0.0.0"
 
 
 def build_prompt(bundle: ContextBundle) -> Prompt:

--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -21,6 +21,15 @@ def list_analyses(directory: Path) -> list[str]:
     return sorted(p.name for p in directory.glob("analyses_*.jsonl"))
 
 
+def _format_ts(value: str) -> str:
+    """Return ``value`` formatted as ``YYYY-MM-DD HH:MM:SS`` if possible."""
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:  # pragma: no cover - best effort
+        return value
+    return parsed.strftime("%Y-%m-%d %H:%M:%S")
+
+
 def _last_occurrence(path: Path) -> str:
     """Best effort extraction of the last occurrence timestamp for ``path``."""
     try:
@@ -33,28 +42,49 @@ def _last_occurrence(path: Path) -> str:
             record = json.loads(last)
             for key in ("time_fired", "timestamp", "time"):
                 if key in record:
-                    return str(record[key])
+                    return _format_ts(str(record[key]))
     except Exception:  # pragma: no cover - defensive
         pass
-    return dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.UTC).isoformat()
+    return _format_ts(dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.UTC).isoformat())  # noqa: E501
 
 
-def render_index(entries: list[tuple[str, str]]) -> bytes:
+def _load_analyses(directory: Path) -> dict[str, dict[str, object]]:
+    """Return mapping of incident file name to latest analysis result."""
+    mapping: dict[str, dict[str, object]] = {}
+    for path in sorted(directory.glob("analyses_*.jsonl")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:  # pragma: no cover - defensive
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                continue
+            inc = record.get("incident")
+            result = record.get("result")
+            if isinstance(inc, str) and isinstance(result, dict):
+                mapping[Path(inc).name] = result
+    return mapping
+
+
+def render_index(entries: list[tuple[str, str, str]]) -> bytes:
     """Render a simple HA-style page for incidents with details links."""
     style = (
         "body{margin:0;padding:16px;font-family:'Roboto',sans-serif;"
-        "background-color:#f5f5f5;}"
-        "\n.card{max-width:800px;margin:0 auto;background:#fff;border-radius:12px;"
-        "box-shadow:0 2px 4px rgba(0,0,0,0.2);}" 
-        "\n.card h1{margin:0;padding:16px;font-size:20px;border-bottom:1px solid "
-        "#e0e0e0;}"
+        "background-color:#121212;color:#e0e0e0;}"
+        "\n.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;"
+        "box-shadow:0 2px 4px rgba(0,0,0,0.6);}"
+        "\n.card h1{margin:0;padding:16px;font-size:20px;border-bottom:1px solid #333;}"
         "\n.list{list-style:none;margin:0;padding:0;}"
         "\n.item{display:flex;align-items:center;justify-content:space-between;"
-        "padding:12px 16px;border-bottom:1px solid #e0e0e0;}"
+        "padding:12px 16px;border-bottom:1px solid #333;}"
         "\n.item:last-child{border-bottom:none;}"
         "\n.item a{color:#03a9f4;text-decoration:none;}"
         "\n.name{flex:1;}"
-        "\n.timestamp{color:#666;font-size:0.9em;margin-right:16px;}"
+        "\n.timestamp{color:#bbb;font-size:0.9em;margin-right:16px;}"
     )
     html_parts = [
         "<html><head><title>HA LLM Ops</title>",
@@ -71,9 +101,9 @@ def render_index(entries: list[tuple[str, str]]) -> bytes:
         "<h1>Incidents</h1>",
         "<ul class='list'>",
     ]
-    for name, last in entries:
+    for desc, last, name in entries:
         html_parts.append(
-            f"<li class='item'><span class='name'>{html.escape(name)}</span>"
+            f"<li class='item'><span class='name'>{html.escape(desc)}</span>"
             f"<span class='timestamp'>{html.escape(last)}</span>"
             f"<a href=\"details/{html.escape(name)}\">View</a></li>"
         )
@@ -81,25 +111,27 @@ def render_index(entries: list[tuple[str, str]]) -> bytes:
     return "".join(html_parts).encode("utf-8")
 
 
-def render_details(
-    name: str, incident_path: Path, analysis_dir: Path | None
-) -> bytes:
+def render_details(name: str, incident_path: Path, analysis: dict[str, object] | None) -> bytes:  # noqa: E501
     """Render an incident details page including its analysis if available."""
-    incident_data = incident_path.read_text(encoding="utf-8")
-    analysis_text = "No analysis available."
-    if analysis_dir is not None:
-        analysis_path = analysis_dir / name.replace("incidents_", "analyses_")
-        if analysis_path.exists():
-            analysis_text = analysis_path.read_text(encoding="utf-8")
+    incident_lines = [
+        line
+        for line in incident_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    occurrences = len(incident_lines)
+    last_seen = _last_occurrence(incident_path)
+    title = name
+    if isinstance(analysis, dict):
+        title = str(analysis.get("impact", name))
     style = (
         "body{margin:0;padding:16px;font-family:'Roboto',sans-serif;"
-        "background-color:#f5f5f5;}"
-        "\n.card{max-width:800px;margin:0 auto;background:#fff;border-radius:12px;"
-        "box-shadow:0 2px 4px rgba(0,0,0,0.2);padding:16px;}"
+        "background-color:#121212;color:#e0e0e0;}"
+        "\n.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;"
+        "box-shadow:0 2px 4px rgba(0,0,0,0.6);padding:16px;}"
         "\nh1{margin-top:0;font-size:20px;}"
-        "\npre{background:#f0f0f0;padding:8px;border-radius:8px;white-space:pre-wrap;"
-        "word-break:break-word;}"
         "\na{color:#03a9f4;text-decoration:none;}"
+        "\npre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;"
+        "word-break:break-word;}"
     )
     parts = [
         "<html><head><title>HA LLM Ops</title>",
@@ -113,14 +145,45 @@ def render_details(
         "</style>",
         "</head><body>",
         "<div class='card'>",
-        f"<h1>{html.escape(name)}</h1>",
-        "<h2>Incident</h2>",
-        f"<pre>{html.escape(incident_data)}</pre>",
+        f"<h1>{html.escape(title)}</h1>",
+        f"<p>Occurrences: {occurrences} {'occurrence' if occurrences == 1 else 'occurrences'}<br>"  # noqa: E501
+        f"Last occurrence: {html.escape(last_seen)}</p>",
         "<h2>Analysis</h2>",
-        f"<pre>{html.escape(analysis_text)}</pre>",
+    ]
+    if isinstance(analysis, dict):
+        parts.extend([
+            "<ul>",
+            f"<li><strong>Root Cause:</strong> {html.escape(str(analysis.get('root_cause', '')))}</li>",  # noqa: E501
+            f"<li><strong>Impact:</strong> {html.escape(str(analysis.get('impact', '')))}</li>",  # noqa: E501
+            f"<li><strong>Confidence:</strong> {html.escape(str(analysis.get('confidence', '')))}</li>",  # noqa: E501
+            f"<li><strong>Risk:</strong> {html.escape(str(analysis.get('risk', '')))}</li>",  # noqa: E501
+        ])
+        actions = analysis.get("candidate_actions")
+        if isinstance(actions, list):
+            parts.append("<li><strong>Candidate Actions:</strong><ul>")
+            for act in actions:
+                if isinstance(act, dict):
+                    action = html.escape(str(act.get("action", "")))
+                    rationale = html.escape(str(act.get("rationale", "")))
+                    parts.append(f"<li>{action}: {rationale}</li>")
+            parts.append("</ul></li>")
+        tests = analysis.get("tests")
+        if isinstance(tests, list):
+            parts.append("<li><strong>Tests:</strong><ul>")
+            for t in tests:
+                parts.append(f"<li>{html.escape(str(t))}</li>")
+            parts.append("</ul></li>")
+        if "recurrence_pattern" in analysis:
+            parts.append(
+                f"<li><strong>Recurrence Pattern:</strong> {html.escape(str(analysis['recurrence_pattern']))}</li>"  # noqa: E501
+            )
+        parts.append("</ul>")
+    else:
+        parts.append("<p>No analysis available.</p>")
+    parts.extend([
         '<p><a href="../">Back</a></p>',
         "</div></body></html>",
-    ]
+    ])
     return "".join(parts).encode("utf-8")
 
 
@@ -131,22 +194,19 @@ def start_http_server(
     host: str = "0.0.0.0",
     port: int = 8000,
 ) -> ThreadingHTTPServer:
-    """Start a thread-based HTTP server exposing incident and analysis bundles.
-
-    The server provides ``/incidents`` and ``/analyses`` endpoints returning JSON
-    lists of bundles found in ``incident_dir`` and ``analysis_dir`` respectively.
-    It runs in a background thread and returns the server instance for optional
-    shutdown.
-    """
-
+    """Start a thread-based HTTP server exposing incident and analysis bundles."""
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: D401 - HTTP handler
             path = unquote(self.path.rstrip("/"))
             if path == "" or path == "/":
-                incidents = []
+                incidents: list[tuple[str, str, str]] = []
+                analyses = (
+                    _load_analyses(analysis_dir) if analysis_dir is not None else {}
+                )
                 for name in list_incidents(incident_dir):
                     inc_path = incident_dir / name
-                    incidents.append((name, _last_occurrence(inc_path)))
+                    desc = str(analyses.get(name, {}).get("impact") or name)
+                    incidents.append((desc, _last_occurrence(inc_path), name))
                 body = render_index(incidents)
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -157,7 +217,10 @@ def start_http_server(
                     self.send_response(404)
                     self.end_headers()
                     return
-                body = render_details(name, file_path, analysis_dir)
+                analyses = (
+                    _load_analyses(analysis_dir) if analysis_dir is not None else {}
+                )
+                body = render_details(name, file_path, analyses.get(name))
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
             elif path == "/incidents":
@@ -196,9 +259,7 @@ def start_http_server(
             self.end_headers()
             self.wfile.write(body)
 
-        def log_message(
-            self, format: str, *args: object
-        ) -> None:  # pragma: no cover - noise
+        def log_message(self, format: str, *args: object) -> None:  # noqa: D401
             return
 
     server = ThreadingHTTPServer((host, port), Handler)

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.11
+version: 0.0.12
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/addons/ha-llm-ops/pyproject.toml
+++ b/addons/ha-llm-ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solidha-agent"
-version = "0.0.0"
+version = "0.0.1"
 description = "HA LLM Ops agent"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solidha-agent"
-version = "0.0.0"
+version = "0.0.1"
 description = "HA LLM Ops agent"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/golden/prompt_output.txt
+++ b/tests/golden/prompt_output.txt
@@ -1,4 +1,4 @@
-SolidHA v0.0.0
+SolidHA v0.0.1
 You are a Home Assistant diagnostics agent. Respond only with JSON matching the provided schema. Do not include explanations or commentary.
 
 Schema:


### PR DESCRIPTION
## Summary
- Show LLM-provided incident impact with formatted timestamps
- Add dark-mode styling and detailed RCA fields on incident details page
- Document repository checks and annotate long lines to satisfy `ruff`
- Resolve prompt builder version from `pyproject.toml` when package metadata is missing and update snapshot
- Document mypy validation and fix related type issues

## Testing
- `ruff check .`
- `mypy agent`
- `pytest --cov=agent.analysis --cov-report=xml --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_689f974eb5748327b1c0bf2f207b4b4d