### PR TITLE
Use OpenAI responses API

### DIFF
--- a/addons/ha-llm-ops/agent/analysis/llm/openai.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/openai.py
@@ -17,7 +17,7 @@ class OpenAI(LLM):
     """LLM adapter using OpenAI's responses endpoint."""
 
     def __init__(
-        self, model: str = "gpt-4o-mini", *, api_key: str | None = None
+        self, model: str = "gpt-5", *, api_key: str | None = None
     ) -> None:
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:

--- a/addons/ha-llm-ops/agent/analysis/llm/openai.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/openai.py
@@ -1,4 +1,4 @@
-"""OpenAI Chat API adapter."""
+"""OpenAI Responses API adapter."""
 
 from __future__ import annotations
 
@@ -10,14 +10,14 @@ import requests
 from .base import LLM
 
 _SYSTEM_PROMPT = "Respond with **only** valid JSON per schema below; no prose."
-_API_URL = "https://api.openai.com/v1/chat/completions"
+_API_URL = "https://api.openai.com/v1/responses"
 
 
 class OpenAI(LLM):
-    """LLM adapter using OpenAI's chat completion endpoint."""
+    """LLM adapter using OpenAI's responses endpoint."""
 
     def __init__(
-        self, model: str = "gpt-3.5-turbo", *, api_key: str | None = None
+        self, model: str = "gpt-4o-mini", *, api_key: str | None = None
     ) -> None:
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
@@ -31,16 +31,25 @@ class OpenAI(LLM):
         }
         payload: dict[str, Any] = {
             "model": self.model,
-            "messages": [
-                {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": prompt},
+            "input": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": _SYSTEM_PROMPT}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": prompt}],
+                },
             ],
             "temperature": 0,
         }
         resp = requests.post(_API_URL, headers=headers, json=payload, timeout=timeout)
         resp.raise_for_status()
         data = cast(dict[str, Any], resp.json())
-        return cast(str, data["choices"][0]["message"]["content"])
+        text = data.get("output_text")
+        if not isinstance(text, str):
+            text = cast(str, data["output"][0]["content"][0]["text"])
+        return text
 
 
 __all__ = ["OpenAI"]

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.15
+version: 0.0.16
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.14
+version: 0.0.15
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_analysis_llm_openai.py
+++ b/tests/test_analysis_llm_openai.py
@@ -36,6 +36,7 @@ def test_openai_generate(monkeypatch) -> None:
     assert result == "{}"
     assert captured["timeout"] == 2.5
     assert captured["headers"]["Authorization"] == "Bearer token"
+    assert captured["json"]["model"] == "gpt-5"
     messages = captured["json"]["input"]
     assert messages[0]["content"][0]["text"] == openai._SYSTEM_PROMPT
     assert messages[1]["content"][0]["text"] == "prompt"

--- a/tests/test_analysis_llm_openai.py
+++ b/tests/test_analysis_llm_openai.py
@@ -24,7 +24,7 @@ def test_openai_generate(monkeypatch) -> None:
                 pass
 
             def json(self) -> dict:
-                return {"choices": [{"message": {"content": "{}"}}]}
+                return {"output": [{"content": [{"text": "{}"}]}]}
 
         return Resp()
 
@@ -36,6 +36,6 @@ def test_openai_generate(monkeypatch) -> None:
     assert result == "{}"
     assert captured["timeout"] == 2.5
     assert captured["headers"]["Authorization"] == "Bearer token"
-    messages = captured["json"]["messages"]
-    assert messages[0]["content"] == openai._SYSTEM_PROMPT
-    assert messages[1]["content"] == "prompt"
+    messages = captured["json"]["input"]
+    assert messages[0]["content"][0]["text"] == openai._SYSTEM_PROMPT
+    assert messages[1]["content"][0]["text"] == "prompt"


### PR DESCRIPTION
## Summary
- call OpenAI's new responses endpoint and default to gpt-4o-mini
- adjust OpenAI adapter tests for new JSON schema
- bump addon version to 0.0.15

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689faf76056483278210d5fd634137ea