### PR TITLE
refactor: move HTML to templates

### DIFF
--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -1,0 +1,18 @@
+<html><head><title>HA LLM Ops</title>
+<link rel='preconnect' href='https://fonts.gstatic.com'>
+<link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap' rel='stylesheet'>
+<style>
+body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121212;color:#e0e0e0;}
+.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,0.6);padding:16px;}
+h1{margin-top:0;font-size:20px;}
+a{color:#03a9f4;text-decoration:none;}
+pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-break:break-word;}
+</style>
+</head><body>
+<div class='card'>
+<h1>$title</h1>
+<p>Occurrences: $occurrences<br>Last occurrence: $last_seen</p>
+<h2>Analysis</h2>
+$analysis
+<p><a href="../">Back</a></p>
+</div></body></html>

--- a/addons/ha-llm-ops/agent/templates/index.html
+++ b/addons/ha-llm-ops/agent/templates/index.html
@@ -1,0 +1,21 @@
+<html><head><title>HA LLM Ops</title>
+<link rel='preconnect' href='https://fonts.gstatic.com'>
+<link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap' rel='stylesheet'>
+<style>
+body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121212;color:#e0e0e0;}
+.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,0.6);}
+.card h1{margin:0;padding:16px;font-size:20px;border-bottom:1px solid #333;}
+.list{list-style:none;margin:0;padding:0;}
+.item{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid #333;}
+.item:last-child{border-bottom:none;}
+.item a{color:#03a9f4;text-decoration:none;}
+.name{flex:1;}
+.timestamp{color:#bbb;font-size:0.9em;margin-right:16px;}
+</style>
+</head><body>
+<div class='card'>
+<h1>Incidents</h1>
+<ul class='list'>
+$items
+</ul>
+</div></body></html>

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.16
+version: 0.0.17
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/addons/ha-llm-ops/pyproject.toml
+++ b/addons/ha-llm-ops/pyproject.toml
@@ -43,3 +43,6 @@ pythonpath = ["."]
 
 [tool.setuptools]
 packages = ["agent"]
+
+[tool.setuptools.package-data]
+"agent" = ["templates/*.html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ pythonpath = ["."]
 
 [tool.setuptools]
 packages = ["agent"]
+
+[tool.setuptools.package-data]
+"agent" = ["templates/*.html"]

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -95,7 +95,7 @@ def test_http_details_page(devux: ModuleType, tmp_path: Path) -> None:
         )
         assert resp.status_code == 200
         assert "system broken" in resp.text
-        assert "1 occurrence" in resp.text
+        assert "Occurrences: 1" in resp.text
         assert "Candidate Actions" in resp.text
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- render DevUX pages from external HTML templates
- drop singular/plural wording by simplifying occurrence text
- package static templates and update add-on version

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb32141248327a828621ea7e9bb14