### PR TITLE
feat: support OpenAI project

### DIFF
--- a/addons/ha-llm-ops/agent/analysis/llm/openai.py
+++ b/addons/ha-llm-ops/agent/analysis/llm/openai.py
@@ -17,11 +17,16 @@ class OpenAI(LLM):
     """LLM adapter using OpenAI's responses endpoint."""
 
     def __init__(
-        self, model: str = "gpt-5", *, api_key: str | None = None
+        self,
+        model: str = "gpt-5",
+        *,
+        api_key: str | None = None,
+        project_id: str | None = None,
     ) -> None:
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
             raise RuntimeError("OPENAI_API_KEY is not set")
+        self.project_id = project_id or os.getenv("OPENAI_PROJECT_ID")
         self.model = model
 
     def generate(self, prompt: str, *, timeout: float) -> str:
@@ -29,6 +34,8 @@ class OpenAI(LLM):
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
+        if self.project_id:
+            headers["OpenAI-Project"] = self.project_id
         payload: dict[str, Any] = {
             "model": self.model,
             "input": [

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.16
+version: 0.0.17
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_analysis_llm_openai.py
+++ b/tests/test_analysis_llm_openai.py
@@ -36,7 +36,36 @@ def test_openai_generate(monkeypatch) -> None:
     assert result == "{}"
     assert captured["timeout"] == 2.5
     assert captured["headers"]["Authorization"] == "Bearer token"
+    assert "OpenAI-Project" not in captured["headers"]
     assert captured["json"]["model"] == "gpt-5"
     messages = captured["json"]["input"]
     assert messages[0]["content"][0]["text"] == openai._SYSTEM_PROMPT
     assert messages[1]["content"][0]["text"] == "prompt"
+
+
+def test_openai_generate_with_project(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "proj")
+
+    captured = {}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.update(
+            {"url": url, "headers": headers, "json": json, "timeout": timeout}
+        )
+
+        class Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"output": [{"content": [{"text": "{}"}]}]}
+
+        return Resp()
+
+    monkeypatch.setattr(openai.requests, "post", fake_post)
+
+    llm = openai.OpenAI()
+    llm.generate("prompt", timeout=1.0)
+
+    assert captured["headers"]["OpenAI-Project"] == "proj"


### PR DESCRIPTION
## Summary
- support project-level OpenAI API keys by forwarding `OPENAI_PROJECT_ID`
- cover project header behavior in tests
- bump HA LLM Ops add-on to 0.0.17

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`
- `curl https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" -s | head`
- `curl https://api.openai.com/v1/responses -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" -d '{"model":"gpt-4.1-mini","input":"Hello"}' -s`


------
https://chatgpt.com/codex/tasks/task_e_689fb3d437248327bf7770dd8d307d39