### PR TITLE
Expose incident and RCA details in dev UI

### DIFF
--- a/addons/ha-llm-ops/agent/observability.py
+++ b/addons/ha-llm-ops/agent/observability.py
@@ -10,8 +10,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TextIO
 
-import websockets
-from websockets.exceptions import ConnectionClosed, InvalidHandshake
+import websockets  # type: ignore[import-not-found]
+from websockets.exceptions import (  # type: ignore[import-not-found]
+    ConnectionClosed,
+    InvalidHandshake,
+)
 
 
 class AuthenticationError(RuntimeError):

--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -12,6 +12,8 @@ pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-b
 <div class='card'>
 <h1>$title</h1>
 <p>Occurrences: $occurrences<br>Last occurrence: $last_seen</p>
+<h2>Incident</h2>
+$incident
 <h2>Analysis</h2>
 $analysis
 <p><a href="../">Back</a></p>

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.17
+version: 0.0.18
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -47,6 +47,7 @@ def test_http_root_page(devux: ModuleType, tmp_path: Path) -> None:
     ana_record = {
         "incident": str(inc),
         "result": {
+            "summary": "summary",
             "root_cause": "rc",
             "impact": "system broken",
             "confidence": 0.5,
@@ -62,7 +63,7 @@ def test_http_root_page(devux: ModuleType, tmp_path: Path) -> None:
         port = server.server_address[1]
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
         assert resp.status_code == 200
-        assert "system broken" in resp.text
+        assert "summary" in resp.text
         assert 'href="details/incidents_1.jsonl"' in resp.text
     finally:
         server.shutdown()
@@ -74,6 +75,7 @@ def test_http_details_page(devux: ModuleType, tmp_path: Path) -> None:
     ana_record = {
         "incident": str(inc),
         "result": {
+            "summary": "summary",
             "root_cause": "rc",
             "impact": "system broken",
             "confidence": 0.5,
@@ -94,9 +96,12 @@ def test_http_details_page(devux: ModuleType, tmp_path: Path) -> None:
             f"http://127.0.0.1:{port}/details/incidents_1.jsonl", timeout=5
         )
         assert resp.status_code == 200
+        assert "summary" in resp.text
         assert "system broken" in resp.text
         assert "Occurrences: 1" in resp.text
         assert "Candidate Actions" in resp.text
+        assert "why" in resp.text
+        assert "time_fired" in resp.text
     finally:
         server.shutdown()
 


### PR DESCRIPTION
## Summary
- Surface analysis summary and incident lines in the DevUX details view
- Prefer analysis summaries for incident listings and show action rationales
- Bump add-on version and silence missing websockets typing for mypy

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb85612d08327b81e6a76511d11ed