### PR TITLE
feat: allow incident deletion

### DIFF
--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -16,5 +16,5 @@ pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-b
 $incident
 <h2>Analysis</h2>
 $analysis
-<p><a href="../">Back</a></p>
+<p><a href="../">Back</a> | <a href="../delete/$name">Delete</a></p>
 </div></body></html>

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.20
+version: 0.0.21
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.19
+version: 0.0.20
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:


### PR DESCRIPTION
## Summary
- support deleting incidents and associated analyses through dev server
- add Delete link on incident details page
- bump add-on version to 0.0.20

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc7a6959c83279c44abd0e9f89e35