### PR TITLE
feat: add executor policy and contracts

### DIFF
--- a/addons/ha-llm-ops/agent/executor/__init__.py
+++ b/addons/ha-llm-ops/agent/executor/__init__.py
@@ -1,0 +1,3 @@
+"""Executor package for guarded actions."""
+
+__all__: list[str] = []

--- a/addons/ha-llm-ops/agent/executor/action_execution_v1.json
+++ b/addons/ha-llm-ops/agent/executor/action_execution_v1.json
@@ -1,0 +1,42 @@
+{
+  "$defs": {
+    "ActionProposal": {
+      "description": "LLM-provided proposal for an action.",
+      "properties": {
+        "action_id": {
+          "description": "Identifier of the proposed action",
+          "title": "Action Id",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": true,
+          "description": "Parameters for the action",
+          "title": "Params",
+          "type": "object"
+        }
+      },
+      "required": [
+        "action_id"
+      ],
+      "title": "ActionProposal",
+      "type": "object"
+    }
+  },
+  "description": "Request to execute a previously proposed action.",
+  "properties": {
+    "proposal": {
+      "$ref": "#/$defs/ActionProposal"
+    },
+    "dry_run": {
+      "default": false,
+      "description": "Whether to simulate without applying",
+      "title": "Dry Run",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "proposal"
+  ],
+  "title": "ActionExecution",
+  "type": "object"
+}

--- a/addons/ha-llm-ops/agent/executor/action_proposal_v1.json
+++ b/addons/ha-llm-ops/agent/executor/action_proposal_v1.json
@@ -1,0 +1,21 @@
+{
+  "description": "LLM-provided proposal for an action.",
+  "properties": {
+    "action_id": {
+      "description": "Identifier of the proposed action",
+      "title": "Action Id",
+      "type": "string"
+    },
+    "params": {
+      "additionalProperties": true,
+      "description": "Parameters for the action",
+      "title": "Params",
+      "type": "object"
+    }
+  },
+  "required": [
+    "action_id"
+  ],
+  "title": "ActionProposal",
+  "type": "object"
+}

--- a/addons/ha-llm-ops/agent/executor/contracts.py
+++ b/addons/ha-llm-ops/agent/executor/contracts.py
@@ -1,0 +1,70 @@
+"""Contracts for executor actions and results."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ActionProposal(BaseModel):
+    """LLM-provided proposal for an action."""
+
+    action_id: str = Field(..., description="Identifier of the proposed action")
+    params: dict[str, Any] = Field(
+        default_factory=dict, description="Parameters for the action"
+    )
+
+
+class ActionExecution(BaseModel):
+    """Request to execute a previously proposed action."""
+
+    proposal: ActionProposal
+    dry_run: bool = Field(False, description="Whether to simulate without applying")
+
+
+class ExecutionResult(BaseModel):
+    """Outcome of executing an action."""
+
+    action_id: str = Field(..., description="Identifier of the executed action")
+    success: bool = Field(..., description="Whether the action succeeded")
+    detail: str | None = Field(None, description="Additional execution details")
+    snapshot_id: str | None = Field(
+        None, description="Snapshot ID used for backup before execution"
+    )
+
+
+def export_schemas(base_path: Path | None = None) -> list[Path]:
+    """Export JSON schemas for executor contracts and return their paths."""
+
+    if base_path is None:
+        base_path = Path(__file__).resolve().parent
+    models: list[tuple[type[BaseModel], str]] = [
+        (ActionProposal, "action_proposal_v1.json"),
+        (ActionExecution, "action_execution_v1.json"),
+        (ExecutionResult, "execution_result_v1.json"),
+    ]
+    paths: list[Path] = []
+    for model, name in models:
+        schema = model.model_json_schema()
+        path = base_path / name
+        content = json.dumps(schema, indent=2) + "\n"
+        existing = path.read_text() if path.exists() else ""
+        if existing != content:
+            path.write_text(content)
+        paths.append(path)
+    return paths
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    export_schemas()
+
+
+__all__ = [
+    "ActionProposal",
+    "ActionExecution",
+    "ExecutionResult",
+    "export_schemas",
+]

--- a/addons/ha-llm-ops/agent/executor/execution_result_v1.json
+++ b/addons/ha-llm-ops/agent/executor/execution_result_v1.json
@@ -1,0 +1,47 @@
+{
+  "description": "Outcome of executing an action.",
+  "properties": {
+    "action_id": {
+      "description": "Identifier of the executed action",
+      "title": "Action Id",
+      "type": "string"
+    },
+    "success": {
+      "description": "Whether the action succeeded",
+      "title": "Success",
+      "type": "boolean"
+    },
+    "detail": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Additional execution details",
+      "title": "Detail"
+    },
+    "snapshot_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Snapshot ID used for backup before execution",
+      "title": "Snapshot Id"
+    }
+  },
+  "required": [
+    "action_id",
+    "success"
+  ],
+  "title": "ExecutionResult",
+  "type": "object"
+}

--- a/addons/ha-llm-ops/agent/executor/policy.py
+++ b/addons/ha-llm-ops/agent/executor/policy.py
@@ -1,0 +1,38 @@
+"""Policy models and loading utilities for executor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+from yaml import safe_load
+
+
+class Policy(BaseModel):
+    """Describe permissions and restrictions for a specific action."""
+
+    action_id: str = Field(..., description="Identifier of the action")
+    allowed: bool = Field(..., description="Whether the action is permitted")
+    conditions: dict[str, Any] = Field(
+        default_factory=dict, description="Additional conditions to satisfy"
+    )
+    cooldown_s: int | None = Field(
+        default=None, ge=0, description="Cooldown period in seconds"
+    )
+
+
+def load_policies(path: Path) -> list[Policy]:
+    """Load policies from ``policy.yaml`` located at ``path`` or its parent."""
+
+    policy_path = path / "policy.yaml" if path.is_dir() else path
+    try:
+        raw = safe_load(policy_path.read_text()) or []
+    except FileNotFoundError:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("policy.yaml must contain a list of policies")
+    return [Policy.model_validate(item) for item in raw]
+
+
+__all__ = ["Policy", "load_policies"]

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.25
+version: 0.0.26
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/golden/policy_invalid.yaml
+++ b/tests/golden/policy_invalid.yaml
@@ -1,0 +1,4 @@
+- action_id: restart_integration
+  conditions:
+    integration: zha
+  cooldown_s: 60

--- a/tests/golden/policy_valid.yaml
+++ b/tests/golden/policy_valid.yaml
@@ -1,0 +1,5 @@
+- action_id: restart_integration
+  allowed: true
+  conditions:
+    integration: zha
+  cooldown_s: 60

--- a/tests/test_executor_contracts.py
+++ b/tests/test_executor_contracts.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from agent.executor.contracts import (
+    ActionExecution,
+    ActionProposal,
+    ExecutionResult,
+)
+
+
+def test_schema_matches_export() -> None:
+    base = Path("agent/executor")
+    cases = [
+        (ActionProposal, "action_proposal_v1.json"),
+        (ActionExecution, "action_execution_v1.json"),
+        (ExecutionResult, "execution_result_v1.json"),
+    ]
+    for model, name in cases:
+        exported = json.loads((base / name).read_text())
+        assert exported == model.model_json_schema()
+
+
+def test_roundtrip() -> None:
+    proposal = ActionProposal(action_id="restart", params={"id": 1})
+    execution = ActionExecution(proposal=proposal, dry_run=True)
+    result = ExecutionResult(
+        action_id="restart", success=True, detail="ok", snapshot_id="1"
+    )
+
+    for model, instance in [
+        (ActionProposal, proposal),
+        (ActionExecution, execution),
+        (ExecutionResult, result),
+    ]:
+        data = json.loads(instance.model_dump_json())
+        model.model_validate(data)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agent.executor.policy import load_policies
+
+
+def test_load_policy_valid() -> None:
+    policies = load_policies(Path("tests/golden/policy_valid.yaml"))
+    assert len(policies) == 1
+    p = policies[0]
+    assert p.action_id == "restart_integration"
+    assert p.allowed is True
+    assert p.conditions == {"integration": "zha"}
+    assert p.cooldown_s == 60
+
+
+def test_load_policy_invalid() -> None:
+    with pytest.raises(ValidationError):
+        load_policies(Path("tests/golden/policy_invalid.yaml"))
+
+
+def test_load_policy_non_list(tmp_path: Path) -> None:
+    policy_file = tmp_path / "policy.yaml"
+    policy_file.write_text("action: test\n")
+    with pytest.raises(ValueError):
+        load_policies(policy_file)


### PR DESCRIPTION
## Summary
- add Policy model with loader for `policy.yaml`
- define executor contracts and export JSON schemas
- test policy parsing and contract schema roundtrips

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06a2029c88327be14183a3d714368