### PR TITLE
Retry failed incident analysis up to five times

### DIFF
--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.25
+version: 0.0.26
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:


### PR DESCRIPTION
## Summary
- retry failed incident analysis on subsequent runs with a maximum of five attempts
- test analysis runner retry behavior
- bump HA LLM Ops add-on version to 0.0.26

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a077077ec483278adf5dcbbcb032f8