### PR TITLE
Make incident names clickable

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -128,10 +128,12 @@ def render_index(entries: list[tuple[str, int, str, str]]) -> bytes:
     """Render a simple HA-style page for incidents with details links."""
     items = "\n".join(
         (
-            f"<li class='item'><span class='name'>{html.escape(desc)}</span>"
+            "<li class='item'>"
+            f"<a class='name' href=\"details/{html.escape(name)}\">"
+            f"{html.escape(desc)}</a>"
             f"<span class='occurrences'>{occ}</span>"
             f"<span class='timestamp'>{html.escape(last)}</span>"
-            f"<a href=\"details/{html.escape(name)}\">View</a></li>"
+            "</li>"
         )
         for desc, occ, last, name in entries
     )

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.26
+version: 0.0.27
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -66,7 +66,9 @@ def test_http_root_page(devux: ModuleType, tmp_path: Path) -> None:
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
         assert resp.status_code == 200
         assert "summary" in resp.text
-        assert 'href="details/incidents_1.jsonl"' in resp.text
+        assert (
+            "<a class='name' href=\"details/incidents_1.jsonl\">" in resp.text
+        )
         assert "class='occurrences'>1<" in resp.text
     finally:
         server.shutdown()
@@ -129,6 +131,7 @@ def test_http_root_sorted_by_occurrences(
         first = text.find("incidents_1.jsonl")
         second = text.find("incidents_2.jsonl")
         assert first != -1 and second != -1 and first < second
+        assert "<a class='name' href=\"details/incidents_1.jsonl\">" in text
         assert "class='occurrences'>2<" in text
         assert "class='occurrences'>1<" in text
     finally:


### PR DESCRIPTION
## Summary
- Link incident names to details pages for easier navigation
- Cover new markup with tests
- Bump add-on version

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0987ce8f48327b2c68f95b96099d0