### PR TITLE
Remove summary fallbacks in incident listing

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -97,26 +97,6 @@ def _count_occurrences(path: Path) -> int:
         return 0
 
 
-def _short_description(path: Path) -> str:
-    """Best effort short description based on the last incident line."""
-
-    try:
-        last = ""
-        with path.open("r", encoding="utf-8") as f:
-            for line in f:
-                if line.strip():
-                    last = line
-        if not last:
-            return path.name
-        record = json.loads(last)
-        for key in ("message", "msg", "event_type"):
-            if key in record:
-                return str(record[key])
-        return json.dumps(record, sort_keys=True)
-    except Exception:  # pragma: no cover - defensive
-        return path.name
-
-
 def _load_ignored(directory: Path) -> set[str]:
     """Return set of ignored incident file names."""
 
@@ -305,11 +285,7 @@ def start_http_server(
                 for name in list_incidents(incident_dir):
                     inc_path = incident_dir / name
                     ana = analyses.get(name, {})
-                    desc = str(
-                        ana.get("summary")
-                        or ana.get("impact")
-                        or _short_description(inc_path)
-                    )
+                    desc = str(ana.get("summary", ""))
                     occurrences = _count_occurrences(inc_path)
                     is_ignored = name in ignored
                     incidents.append(

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.31
+version: 0.0.32
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -70,7 +70,7 @@ def test_http_root_page(devux: ModuleType, tmp_path: Path) -> None:
         server.shutdown()
 
 
-def test_http_root_page_without_analysis_shows_event(
+def test_http_root_page_without_analysis_has_empty_summary(
     devux: ModuleType, tmp_path: Path
 ) -> None:
     inc = tmp_path / "incidents_1.jsonl"
@@ -81,7 +81,8 @@ def test_http_root_page_without_analysis_shows_event(
         port = server.server_address[1]
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
         assert resp.status_code == 200
-        assert "oops" in resp.text
+        assert "<span class='name'></span>" in resp.text
+        assert "oops" not in resp.text
         assert "class='name'>incidents_1.jsonl<" not in resp.text
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- ensure incident summaries only use LLM-provided content
- remove obsolete short description helper
- update tests and bump add-on version

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b153fefc8327bcef2e3e74557c4f