### PR TITLE
fix: support flat analyses records

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -132,13 +132,23 @@ def _load_analyses(directory: Path) -> dict[str, dict[str, object]]:
             except json.JSONDecodeError:  # pragma: no cover - defensive
                 continue
             inc = record.get("incident")
-            result = record.get("result")
+            if not isinstance(inc, str):
+                continue
             event = record.get("event")
-            if isinstance(inc, str) and isinstance(result, dict):
-                combined = dict(result)
-                if event is not None:
-                    combined["trigger_event"] = event
-                mapping[Path(inc).name] = combined
+            result = record.get("result")
+            combined: dict[str, object] = {}
+            if isinstance(result, dict):
+                combined.update(result)
+            combined.update(
+                {
+                    key: value
+                    for key, value in record.items()
+                    if key not in {"incident", "event", "result"}
+                }
+            )
+            if event is not None:
+                combined["trigger_event"] = event
+            mapping[Path(inc).name] = combined
     return mapping
 
 

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.28
+version: 0.0.29
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant incidents and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -114,6 +114,40 @@ def test_http_details_page(devux: ModuleType, tmp_path: Path) -> None:
         server.shutdown()
 
 
+def test_http_details_page_flat_analysis(devux: ModuleType, tmp_path: Path) -> None:
+    inc = tmp_path / "incidents_1.jsonl"
+    inc.write_text("{}\n", encoding="utf-8")
+    ana_record = {
+        "incident": str(inc),
+        "summary": "summary",
+        "root_cause": "rc",
+        "impact": "system broken",
+        "confidence": 0.5,
+        "risk": "low",
+        "candidate_actions": [{"action": "act", "rationale": "why"}],
+        "tests": ["check"],
+        "recurrence_pattern": "pattern",
+        "event": {"event_type": "trigger"},
+    }
+    (tmp_path / "analyses_1.jsonl").write_text(json.dumps(ana_record), encoding="utf-8")
+    server = devux.start_http_server(
+        tmp_path, analysis_dir=tmp_path, host="127.0.0.1", port=0
+    )
+    try:
+        time.sleep(0.1)
+        port = server.server_address[1]
+        resp = requests.get(
+            f"http://127.0.0.1:{port}/details/incidents_1.jsonl", timeout=5
+        )
+        assert resp.status_code == 200
+        assert "summary" in resp.text
+        assert "system broken" in resp.text
+        assert "Candidate Actions" in resp.text
+        assert "why" in resp.text
+    finally:
+        server.shutdown()
+
+
 def test_http_root_sorted_by_occurrences(
     devux: ModuleType, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure devux can load legacy flat analysis records
- add regression test for flat record compatibility
- bump HA LLM Ops add-on version

## Testing
- `ruff check .`
- `mypy agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b87e3020832781402c134f4ffda8