### PR TITLE
fix: expose dev server

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -19,7 +19,7 @@ def delete_problem(directory: Path, name: str) -> None:
 def render_index(names: list[str]) -> bytes:
     """Render a minimal index page."""
     items = "\n".join(
-        f"<li><a href=\"details/{html.escape(n)}\">{html.escape(n)}</a></li>"
+        f'<li><a href="details/{html.escape(n)}">{html.escape(n)}</a></li>'
         for n in names
     )
     return f"<html><body><ul>{items}</ul></body></html>".encode()
@@ -32,7 +32,10 @@ def render_details(path: Path) -> bytes:
 
 
 def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServer:
-    """Start a simple thread-based HTTP server for problems."""
+    """Start a simple thread-based HTTP server for problems.
+
+    The server binds to ``0.0.0.0`` so Home Assistant can access it via ingress.
+    """
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
@@ -77,7 +80,7 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
                 self.send_response(404)
                 self.end_headers()
 
-    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.46
+version: 0.0.47
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_analysis_e2e.py
+++ b/tests/test_analysis_e2e.py
@@ -86,9 +86,7 @@ def test_end_to_end_problem_flow(tmp_path: Path) -> None:
     second_event = copy.deepcopy(base_event)
     second_event["context"]["id"] = "01K2TCSVD6Y6367NV7ERZSCVF5"
     second_event["time_fired"] = "2025-08-16T21:34:05.830408+00:00"
-    second_event["data"]["new_state"]["context"]["id"] = (
-        "01K2TCSVD6Y6367NV7ERZSCVF5"
-    )
+    second_event["data"]["new_state"]["context"]["id"] = "01K2TCSVD6Y6367NV7ERZSCVF5"
     second_event["data"]["new_state"]["last_changed"] = (
         "2025-08-16T21:34:05.830408+00:00"
     )
@@ -109,8 +107,8 @@ def test_end_to_end_problem_flow(tmp_path: Path) -> None:
             resp["recurrence_pattern"] = "wiz_rgbww_tunable_f8f860_power.*unavailable"
             return json.dumps(resp)
 
-    key = os.getenv("OPENAI_API_KEY")
-    llm = None if key else CountingLLM()
+    os.environ.pop("OPENAI_API_KEY", None)
+    llm = CountingLLM()
     events = [
         {"type": "event", "event": base_event},
         {"type": "event", "event": second_event},
@@ -139,8 +137,7 @@ def test_end_to_end_problem_flow(tmp_path: Path) -> None:
     pattern = re.compile(result.recurrence_pattern)
     assert pattern.search(json.dumps(second_event, sort_keys=True))
     assert second["occurrence"] == 2 and "result" not in second
-    if llm is not None:
-        assert llm.calls == 1
+    assert llm.calls == 1
 
     server = start_http_server(tmp_path, port=0)
     try:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -15,10 +15,11 @@ def test_list_and_delete(tmp_path: Path) -> None:
 
 
 def test_http_server(tmp_path: Path) -> None:
-    (tmp_path / "problems_1.jsonl").write_text("{\"a\":1}\n", encoding="utf-8")
+    (tmp_path / "problems_1.jsonl").write_text('{"a":1}\n', encoding="utf-8")
     server = devux.start_http_server(tmp_path, port=0)
     try:
         time.sleep(0.1)
+        assert server.server_address[0] == "0.0.0.0"
         port = server.server_address[1]
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
         assert "problems_1.jsonl" in resp.text

--- a/tests/test_monitor_docker.py
+++ b/tests/test_monitor_docker.py
@@ -117,7 +117,7 @@ def test_monitor_automation_failure(tmp_path: Path) -> None:
                         token=token,
                         problem_dir=problem_dir,
                         llm=MockLLM(),
-                        limit=1,
+                        limit=3,
                     ),
                     timeout=60,
                 )
@@ -128,9 +128,7 @@ def test_monitor_automation_failure(tmp_path: Path) -> None:
         files = list(problem_dir.glob("problems_*.jsonl"))
         assert files, "No problem files created"
         lines = [
-            json.loads(line)
-            for file in files
-            for line in file.read_text().splitlines()
+            json.loads(line) for file in files for line in file.read_text().splitlines()
         ]
         assert any(
             "nonexistent.does_not_exist" in json.dumps(line) for line in lines


### PR DESCRIPTION
## Summary
- expose dev http server on all interfaces for ingress
- test that server binds to public interface
- bump add-on version
- ensure end-to-end test always uses mock LLM
- allow docker monitor test to capture automation failures

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive agent`
- `pytest -m "not docker" --cov=agent --cov-report=xml --cov-fail-under=98`
- `pytest -m docker -vv` *(fails: Docker daemon not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a1da6d9fa483278ab22223e17e3dc5