### PR TITLE
feat: restore problem UI

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -1,76 +1,288 @@
+"""Development UX utilities like a minimal HTTP incident endpoint."""
+
 from __future__ import annotations
 
+import datetime as dt
+import hashlib
 import html
+import json
+import re
 import threading
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from string import Template
+from typing import Any
+
+
+@dataclass
+class _ProblemEntry:
+    summary: str
+    occurrences: int
+    last_seen: str
+    analysis: dict[str, Any]
+    events: list[str]
+    pattern: re.Pattern[str]
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
 
 def list_problems(directory: Path) -> list[str]:
-    """Return sorted problem file names."""
+    """Return sorted problem log file names."""
+
     return sorted(p.name for p in directory.glob("problems_*.jsonl"))
 
 
-def delete_problem(directory: Path, name: str) -> None:
-    """Delete problem file ``name`` from ``directory``."""
-    (directory / name).unlink(missing_ok=True)
+def _format_ts(value: str) -> str:
+    """Return ``value`` formatted as ``YYYY-MM-DD HH:MM:SS`` if possible."""
+
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:  # pragma: no cover - best effort
+        return value
+    return parsed.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def render_index(names: list[str]) -> bytes:
-    """Render a minimal index page."""
+def _event_ts(event: dict[str, Any]) -> str:
+    for key in ("time_fired", "timestamp", "time"):
+        if key in event:
+            return _format_ts(str(event[key]))
+    return ""
+
+
+def _load_problems(directory: Path) -> dict[str, _ProblemEntry]:
+    """Return mapping of problem key to latest info and events."""
+
+    mapping: dict[str, _ProblemEntry] = {}
+    for path in sorted(directory.glob("problems_*.jsonl")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:  # pragma: no cover - defensive
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                continue
+            event = record.get("event")
+            if not isinstance(event, dict):
+                continue
+            event_json = json.dumps(event, sort_keys=True)
+            ts = _event_ts(event)
+            result = record.get("result")
+            if isinstance(result, dict) and "recurrence_pattern" in result:
+                key = hashlib.sha1(
+                    result["recurrence_pattern"].encode("utf-8")
+                ).hexdigest()
+                pattern = re.compile(result["recurrence_pattern"])
+                entry = mapping.get(key)
+                if entry is None:
+                    summary = str(result.get("summary") or result.get("impact") or key)
+                    entry = _ProblemEntry(
+                        summary=summary,
+                        occurrences=0,
+                        last_seen="",
+                        analysis=result,
+                        events=[],
+                        pattern=pattern,
+                    )
+                    mapping[key] = entry
+                entry.events.append(event_json)
+                entry.occurrences = record.get("occurrence", 1)
+                if ts:
+                    entry.last_seen = ts
+                continue
+            # match existing problems
+            matched: _ProblemEntry | None = None
+            for entry in mapping.values():
+                if entry.pattern.search(event_json):
+                    matched = entry
+                    break
+            if matched is None:
+                continue
+            matched.events.append(event_json)
+            matched.occurrences = record.get("occurrence", matched.occurrences + 1)
+            if ts:
+                matched.last_seen = ts
+    return mapping
+
+
+def delete_problem(directory: Path, key: str) -> None:
+    """Delete all records for problem ``key`` from ``directory``."""
+
+    problems = _load_problems(directory)
+    entry = problems.get(key)
+    if entry is None:
+        return
+    pattern = entry.pattern
+    for path in directory.glob("problems_*.jsonl"):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:  # pragma: no cover - defensive
+            continue
+        new_lines: list[str] = []
+        changed = False
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                new_lines.append(line)
+                continue
+            event = record.get("event")
+            if isinstance(event, dict):
+                event_json = json.dumps(event, sort_keys=True)
+                if pattern.search(event_json):
+                    changed = True
+                    continue
+            new_lines.append(line)
+        if changed:
+            if new_lines:
+                path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+            else:
+                path.unlink(missing_ok=True)
+
+
+def render_index(entries: list[tuple[str, int, str, str]]) -> bytes:
+    """Render a simple HA-style page for problems with details links."""
+
     items = "\n".join(
-        f'<li><a href="details/{html.escape(n)}">{html.escape(n)}</a></li>'
-        for n in names
+        (
+            f"<li class='item'><span class='name'>{html.escape(desc)}</span>"
+            f"<span class='occurrences'>{occ}</span>"
+            f"<span class='timestamp'>{html.escape(last)}</span>"
+            f'<a href="details/{html.escape(name)}">View</a></li>'
+        )
+        for desc, occ, last, name in entries
     )
-    return f"<html><body><ul>{items}</ul></body></html>".encode()
+    template = (TEMPLATE_DIR / "index.html").read_text(encoding="utf-8")
+    body = Template(template).safe_substitute(items=items)
+    return body.encode("utf-8")
 
 
-def render_details(path: Path) -> bytes:
-    """Render raw problem file content."""
-    text = html.escape(path.read_text(encoding="utf-8"))
-    return f"<html><body><pre>{text}</pre></body></html>".encode()
+def _analysis_html(analysis: dict[str, Any]) -> str:
+    parts = ["<ul>"]
+    parts.extend(
+        [
+            (
+                "<li><strong>Summary:</strong> "
+                f"{html.escape(str(analysis.get('summary', '')))}</li>"
+            ),
+            (
+                "<li><strong>Root Cause:</strong> "
+                f"{html.escape(str(analysis.get('root_cause', '')))}</li>"
+            ),
+            (
+                "<li><strong>Impact:</strong> "
+                f"{html.escape(str(analysis.get('impact', '')))}</li>"
+            ),
+            (
+                "<li><strong>Confidence:</strong> "
+                f"{html.escape(str(analysis.get('confidence', '')))}</li>"
+            ),
+            (
+                "<li><strong>Risk:</strong> "
+                f"{html.escape(str(analysis.get('risk', '')))}</li>"
+            ),
+        ]
+    )
+    actions = analysis.get("candidate_actions")
+    if isinstance(actions, list):
+        parts.append("<li><strong>Candidate Actions:</strong><ul>")
+        for act in actions:
+            if isinstance(act, dict):
+                action = html.escape(str(act.get("action", "")))
+                rationale = html.escape(str(act.get("rationale", "")))
+                parts.append(f"<li>{action}: {rationale}</li>")
+        parts.append("</ul></li>")
+    tests = analysis.get("tests")
+    if isinstance(tests, list):
+        parts.append("<li><strong>Tests:</strong><ul>")
+        for t in tests:
+            parts.append(f"<li>{html.escape(str(t))}</li>")
+        parts.append("</ul></li>")
+    if "recurrence_pattern" in analysis:
+        parts.append(
+            "<li><strong>Recurrence Pattern:</strong> "
+            f"{html.escape(str(analysis['recurrence_pattern']))}</li>"
+        )
+    parts.append("</ul>")
+    return "".join(parts)
+
+
+def render_details(name: str, entry: _ProblemEntry) -> bytes:
+    """Render a problem details page including its analysis."""
+
+    incident_html = (
+        "<pre>" + "\n".join(html.escape(line) for line in entry.events) + "</pre>"
+    )
+    analysis_html = _analysis_html(entry.analysis)
+    template = (TEMPLATE_DIR / "details.html").read_text(encoding="utf-8")
+    body = Template(template).safe_substitute(
+        title=html.escape(entry.summary),
+        occurrences=entry.occurrences,
+        last_seen=html.escape(entry.last_seen),
+        incident=incident_html,
+        analysis=analysis_html,
+        name=html.escape(name),
+    )
+    return body.encode("utf-8")
 
 
 def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServer:
-    """Start a simple thread-based HTTP server for problems.
-
-    The server binds to ``0.0.0.0`` so Home Assistant can access it via ingress.
-    """
+    """Start a thread-based HTTP server exposing problem bundles."""
 
     class Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
-            if self.path == "/":
-                body = render_index(list_problems(directory))
+        def do_GET(self) -> None:  # noqa: D401 - HTTP handler
+            path = self.path.rstrip("/")
+            if path == "" or path == "/":
+                problems = _load_problems(directory)
+                entries = [
+                    (p.summary, p.occurrences, p.last_seen, key)
+                    for key, p in problems.items()
+                ]
+                entries.sort(key=lambda x: x[1], reverse=True)
+                body = render_index(entries)
                 self.send_response(200)
-                self.send_header("Content-Type", "text/html")
-                self.end_headers()
-                self.wfile.write(body)
-                return
-            if self.path.startswith("/details/"):
-                name = self.path.split("/", 2)[2]
-                body = render_details(directory / name)
-                self.send_response(200)
-                self.send_header("Content-Type", "text/html")
-                self.end_headers()
-                self.wfile.write(body)
-                return
-            if self.path.startswith("/problems/"):
-                name = self.path.split("/", 2)[2]
-                try:
-                    data = (directory / name).read_bytes()
-                except FileNotFoundError:
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+            elif path.startswith("/details/"):
+                name = path.split("/", 2)[2]
+                problems = _load_problems(directory)
+                entry = problems.get(name)
+                if entry is None:
                     self.send_response(404)
                     self.end_headers()
                     return
+                body = render_details(name, entry)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+            elif path == "/problems":
+                body = json.dumps(list_problems(directory)).encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
+            elif path.startswith("/problems/"):
+                name = path.split("/", 2)[2]
+                file_path = directory / name
+                if not file_path.exists():
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                body = file_path.read_bytes()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+            else:
+                self.send_response(404)
                 self.end_headers()
-                self.wfile.write(data)
                 return
-            self.send_response(404)
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
+            self.wfile.write(body)
 
-        def do_DELETE(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        def do_DELETE(self) -> None:  # noqa: D401 - HTTP handler
             if self.path.startswith("/delete/"):
                 name = self.path.split("/", 2)[2]
                 delete_problem(directory, name)
@@ -79,6 +291,9 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
             else:
                 self.send_response(404)
                 self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: D401
+            return
 
     server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -1,0 +1,20 @@
+<html><head><title>HA LLM Ops</title>
+<link rel='preconnect' href='https://fonts.gstatic.com'>
+<link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap' rel='stylesheet'>
+<style>
+body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121212;color:#e0e0e0;}
+.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,0.6);padding:16px;}
+h1{margin-top:0;font-size:20px;}
+a{color:#03a9f4;text-decoration:none;}
+pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-break:break-word;}
+</style>
+</head><body>
+<div class='card'>
+<h1>$title</h1>
+<p>Occurrences: $occurrences<br>Last occurrence: $last_seen</p>
+<h2>Events</h2>
+$incident
+<h2>Analysis</h2>
+$analysis
+<p><a href="../">Back</a> | <a href="../delete/$name">Delete</a></p>
+</div></body></html>

--- a/addons/ha-llm-ops/agent/templates/index.html
+++ b/addons/ha-llm-ops/agent/templates/index.html
@@ -1,0 +1,22 @@
+<html><head><title>HA LLM Ops</title>
+<link rel='preconnect' href='https://fonts.gstatic.com'>
+<link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap' rel='stylesheet'>
+<style>
+body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121212;color:#e0e0e0;}
+.card{max-width:800px;margin:0 auto;background:#1e1e1e;border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,0.6);}
+.card h1{margin:0;padding:16px;font-size:20px;border-bottom:1px solid #333;}
+.list{list-style:none;margin:0;padding:0;}
+.item{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid #333;}
+.item:last-child{border-bottom:none;}
+.item a{color:#03a9f4;text-decoration:none;}
+.name{flex:1;}
+.occurrences{color:#bbb;font-size:0.9em;margin-right:16px;}
+.timestamp{color:#bbb;font-size:0.9em;margin-right:16px;}
+</style>
+</head><body>
+<div class='card'>
+<h1>Problems</h1>
+<ul class='list'>
+$items
+</ul>
+</div></body></html>

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.47
+version: 0.0.48
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_analysis_e2e.py
+++ b/tests/test_analysis_e2e.py
@@ -144,7 +144,7 @@ def test_end_to_end_problem_flow(tmp_path: Path) -> None:
         time.sleep(0.1)
         port = server.server_address[1]
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
-        assert files[0].name in resp.text
+        assert result.summary in resp.text
         resp = requests.get(
             f"http://127.0.0.1:{port}/problems/{files[0].name}", timeout=5
         )

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -1,3 +1,5 @@
+import json
+import re
 import time
 from pathlib import Path
 
@@ -6,43 +8,66 @@ import requests
 from agent import devux
 
 
+def _sample_result() -> dict:
+    return {
+        "summary": "Problem summary",
+        "root_cause": "Root cause",
+        "impact": "Impact",
+        "confidence": 0.5,
+        "candidate_actions": [],
+        "risk": "low",
+        "tests": [],
+        "recurrence_pattern": "foo",
+    }
+
+
+def _record(
+    time_str: str,
+    occurrence: int,
+    result: dict | None = None,
+    extra: dict | None = None,
+) -> str:
+    event: dict[str, object] = {"time": time_str}
+    if extra:
+        event.update(extra)
+    data: dict[str, object] = {"event": event, "occurrence": occurrence}
+    if result is not None:
+        data["result"] = result
+    return json.dumps(data)
+
+
 def test_list_and_delete(tmp_path: Path) -> None:
-    (tmp_path / "problems_1.jsonl").write_text("{}\n", encoding="utf-8")
-    (tmp_path / "problems_2.jsonl").write_text("{}\n", encoding="utf-8")
-    assert devux.list_problems(tmp_path) == ["problems_1.jsonl", "problems_2.jsonl"]
-    devux.delete_problem(tmp_path, "problems_1.jsonl")
-    assert devux.list_problems(tmp_path) == ["problems_2.jsonl"]
+    rec1 = _record("2024-01-01T00:00:00Z", 1, _sample_result(), {"msg": "foo"})
+    rec2 = _record("2024-01-02T00:00:00Z", 2, extra={"msg": "foo"})
+    path = tmp_path / "problems_1.jsonl"
+    path.write_text(f"{rec1}\n{rec2}\n", encoding="utf-8")
+
+    problems = devux._load_problems(tmp_path)
+    key = next(iter(problems))
+    assert problems[key].occurrences == 2
+
+    devux.delete_problem(tmp_path, key)
+    assert not path.exists()
 
 
 def test_http_server(tmp_path: Path) -> None:
-    (tmp_path / "problems_1.jsonl").write_text('{"a":1}\n', encoding="utf-8")
+    rec1 = _record("2024-01-01T00:00:00Z", 1, _sample_result(), {"msg": "foo"})
+    path = tmp_path / "problems_1.jsonl"
+    path.write_text(f"{rec1}\n", encoding="utf-8")
+
     server = devux.start_http_server(tmp_path, port=0)
     try:
         time.sleep(0.1)
-        assert server.server_address[0] == "0.0.0.0"
         port = server.server_address[1]
         resp = requests.get(f"http://127.0.0.1:{port}/", timeout=5)
-        assert "problems_1.jsonl" in resp.text
-        resp = requests.get(
-            f"http://127.0.0.1:{port}/problems/problems_1.jsonl", timeout=5
-        )
-        assert resp.json() == {"a": 1}
-        resp = requests.get(
-            f"http://127.0.0.1:{port}/details/problems_1.jsonl", timeout=5
-        )
-        assert "a" in resp.text
-        resp = requests.get(f"http://127.0.0.1:{port}/unknown", timeout=5)
-        assert resp.status_code == 404
-        resp = requests.get(
-            f"http://127.0.0.1:{port}/problems/missing.jsonl", timeout=5
-        )
-        assert resp.status_code == 404
-        resp = requests.delete(
-            f"http://127.0.0.1:{port}/delete/problems_1.jsonl", timeout=5
-        )
+        assert "Problem summary" in resp.text
+        match = re.search(r"details/(\w+)", resp.text)
+        assert match is not None
+        key = match.group(1)
+        resp = requests.get(f"http://127.0.0.1:{port}/details/{key}", timeout=5)
+        assert "Root Cause" in resp.text
+        resp = requests.delete(f"http://127.0.0.1:{port}/delete/{key}", timeout=5)
         assert resp.status_code == 200
-        assert not (tmp_path / "problems_1.jsonl").exists()
-        resp = requests.delete(f"http://127.0.0.1:{port}/oops", timeout=5)
-        assert resp.status_code == 404
+        assert not path.exists()
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- restore styled web UI for problem history with detail pages
- support deleting logged problems and group events by recurrence patterns
- bump add-on version to 0.0.48

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .` (fails: Duplicate module named `agent`)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1df67a9408327b10c3edb34edcb45