### PR TITLE
Add mdformat dev dependency and testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,5 @@
 - No migration support required for breaking changes: keep the code simple, if there are breaking changes mention this and we will ask users to delete the data.
 - No secrets in code.
 - All new code has to be completely covered by tests that make sense. Update tests with every behavior change, if fixing a bug add a regression test.
-- Run `ruff check . --fix && ruff format . && mdformat . && mypy --install-types --non-interactive .` to validate code changes before submitting.
+- Run `pip install ".[dev]" && ruff check . --fix && ruff format . && mdformat . && mypy --install-types --non-interactive .` to validate code changes before submitting.
 - Bump version in addons/ha-llm-ops/config.yaml.

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.48
+version: 0.0.49
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "ruff>=0.1.7",
     "mypy>=1.7",
     "pre-commit>=3.4",
+    "mdformat>=0.7",
     "types-requests",
     "types-PyYAML",
 ]


### PR DESCRIPTION
## Summary
- include mdformat in development dependencies
- document installing dev dependencies before running linting and type checks
- bump HA LLM Ops add-on version to 0.0.49

## Testing
- `pip install ".[dev]"`
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .` *(fails: Duplicate module named "agent")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a20fd730f08327a1ab11c0576e2895