### PR TITLE
Handle invalid regex patterns in devux

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -74,10 +74,12 @@ def _load_problems(directory: Path) -> dict[str, _ProblemEntry]:
             ts = _event_ts(event)
             result = record.get("result")
             if isinstance(result, dict) and "recurrence_pattern" in result:
-                key = hashlib.sha1(
-                    result["recurrence_pattern"].encode("utf-8")
-                ).hexdigest()
-                pattern = re.compile(result["recurrence_pattern"], re.DOTALL)
+                pattern_str = result["recurrence_pattern"]
+                key = hashlib.sha1(pattern_str.encode("utf-8")).hexdigest()
+                try:
+                    pattern = re.compile(pattern_str, re.DOTALL)
+                except re.error:
+                    pattern = re.compile(re.escape(pattern_str), re.DOTALL)
                 entry = mapping.get(key)
                 if entry is None:
                     summary = str(result.get("summary") or result.get("impact") or key)

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.51
+version: 0.0.52
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:


### PR DESCRIPTION
## Summary
- guard against invalid recurrence pattern regexes in devux
- add regression test for malformed pattern handling
- bump ha_llm_ops add-on version to 0.0.52

## Testing
- `pytest tests/test_devux.py::test_load_problems_invalid_pattern --no-cov -q`
- `pip install ".[dev]" && ruff check . --fix && ruff format . && mdformat . && mypy --install-types --non-interactive .` *(fails: Duplicate module named "agent")*


------
https://chatgpt.com/codex/tasks/task_e_68a2313151c483278b74c37da2a00e20