### PR TITLE
Fix problem deletion and trim log noise

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -241,6 +241,13 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: D401 - HTTP handler
             path = self.path.rstrip("/")
+            if path.startswith("/delete/"):
+                name = path.split("/", 2)[2]
+                delete_problem(directory, name)
+                self.send_response(303)
+                self.send_header("Location", "/")
+                self.end_headers()
+                return
             if path == "" or path == "/":
                 problems = _load_problems(directory)
                 entries = [

--- a/addons/ha-llm-ops/agent/problems.py
+++ b/addons/ha-llm-ops/agent/problems.py
@@ -219,10 +219,10 @@ async def monitor(
                         matched["count"] += 1
                         LOGGER.info(
                             "Existing problem occurred again: pattern=%s occurrence=%s "
-                            "event=%s",
+                            "type=%s",
                             matched["pattern"].pattern,
                             matched["count"],
-                            event_json,
+                            etype,
                         )
                         record = {"event": event, "occurrence": matched["count"]}
 

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.52
+version: 0.0.53
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -98,6 +98,12 @@ def test_http_server(tmp_path: Path) -> None:
         assert requests.get(f"{base}/problems/nope", timeout=5).status_code == 404
         assert requests.get(f"{base}/unknown", timeout=5).status_code == 404
         assert requests.delete(f"{base}/nope", timeout=5).status_code == 404
+        resp = requests.get(f"{base}/delete/{key}", timeout=5)
+        assert resp.status_code == 200
+        assert not path.exists()
+
+        # Recreate problem and delete via DELETE method
+        path.write_text(f"{rec1}\n", encoding="utf-8")
         resp = requests.delete(f"{base}/delete/{key}", timeout=5)
         assert resp.status_code == 200
         assert not path.exists()

--- a/tests/test_monitor_logging.py
+++ b/tests/test_monitor_logging.py
@@ -82,6 +82,10 @@ def test_logging_success_and_existing(
         r.levelno == logging.INFO and "Existing problem occurred again" in r.message
         for r in caplog.records
     )
+    assert not any(
+        "Existing problem occurred again" in r.message and "extra" in r.message
+        for r in caplog.records
+    )
 
 
 def test_logging_analysis_failure(


### PR DESCRIPTION
## Summary
- Allow GET `/delete/<key>` requests so the problem details page can delete items via link
- Reduce log verbosity for recurring problems by omitting full event payload
- Add regression tests and bump add-on version

## Testing
- `pip install ".[dev]"`
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23fe6b1008327bcecd8be0aa6300d