### PR TITLE
Add ignore toggles and reanalysis to problem viewer

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -14,6 +14,11 @@ from pathlib import Path
 from string import Template
 from typing import Any
 
+from .llm import LLM, create_llm
+from .parse import parse_result
+from .problems import ProblemLogger
+from .prompt import build_rca_prompt
+
 
 @dataclass
 class _ProblemEntry:
@@ -23,6 +28,7 @@ class _ProblemEntry:
     analysis: dict[str, Any]
     events: list[str]
     pattern: re.Pattern[str]
+    ignored: bool = False
 
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
@@ -90,10 +96,15 @@ def _load_problems(directory: Path) -> dict[str, _ProblemEntry]:
                         analysis=result,
                         events=[],
                         pattern=pattern,
+                        ignored=(directory / f"{key}.ignored").exists(),
                     )
                     mapping[key] = entry
                 entry.events.append(event_json)
                 entry.occurrences = record.get("occurrence", 1)
+                entry.analysis = result
+                entry.summary = str(
+                    result.get("summary") or result.get("impact") or key
+                )
                 if ts:
                     entry.last_seen = ts
                 continue
@@ -149,17 +160,60 @@ def delete_problem(directory: Path, key: str) -> None:
                 path.unlink(missing_ok=True)
 
 
-def render_index(entries: list[tuple[str, int, str, str]]) -> bytes:
+def ignore_problem(directory: Path, key: str) -> None:
+    """Mark problem ``key`` as ignored."""
+
+    (directory / f"{key}.ignored").write_text("1", encoding="utf-8")
+
+
+def unignore_problem(directory: Path, key: str) -> None:
+    """Remove ignore flag for problem ``key``."""
+
+    (directory / f"{key}.ignored").unlink(missing_ok=True)
+
+
+def reanalyze_problem(directory: Path, key: str, *, llm: LLM | None = None) -> None:
+    """Re-run analysis for problem ``key`` and append the result."""
+
+    problems = _load_problems(directory)
+    entry = problems.get(key)
+    if entry is None or not entry.events:
+        return
+    try:
+        event_ctx = json.loads(entry.events[-1])
+    except json.JSONDecodeError:  # pragma: no cover - defensive
+        return
+    llm = llm or create_llm()
+    try:
+        prompt = build_rca_prompt(event_ctx)
+        raw = llm.generate(prompt, timeout=300)
+        result = parse_result(raw).model_dump()
+    except Exception:  # pragma: no cover - best effort
+        return
+    logger = ProblemLogger(directory)
+    logger.write(
+        {
+            "event": event_ctx,
+            "occurrence": entry.occurrences,
+            "result": result,
+        }
+    )
+
+
+def render_index(entries: list[tuple[str, int, str, str, bool]]) -> bytes:
     """Render a simple HA-style page for problems with details links."""
 
     items = "\n".join(
         (
-            f"<li class='item'><span class='name'>{html.escape(desc)}</span>"
+            "<li class='item'>"
+            f"<span class='name'>{html.escape(desc)}"
+            + (" <span class='ignored'>ignored</span>" if ignored else "")
+            + "</span>"
             f"<span class='occurrences'>{occ}</span>"
             f"<span class='timestamp'>{html.escape(last)}</span>"
             f'<a href="details/{html.escape(name)}">View</a></li>'
         )
-        for desc, occ, last, name in entries
+        for desc, occ, last, name, ignored in entries
     )
     template = (TEMPLATE_DIR / "index.html").read_text(encoding="utf-8")
     body = Template(template).safe_substitute(items=items)
@@ -223,14 +277,25 @@ def render_details(name: str, entry: _ProblemEntry) -> bytes:
         "<pre>" + "\n".join(html.escape(line) for line in entry.events) + "</pre>"
     )
     analysis_html = _analysis_html(entry.analysis)
+    ignore_action = "unignore" if entry.ignored else "ignore"
+    ignore_label = "Unignore" if entry.ignored else "Ignore"
+    actions = (
+        "<p>"
+        "<a class='button' href='../'>Back</a> "
+        f"<a class='button' href='../reanalyze/{html.escape(name)}'>Reanalyze</a> "
+        f"<a class='button' href='../{ignore_action}/{html.escape(name)}'>"
+        f"{ignore_label}</a> "
+        f"<a class='button danger' href='../delete/{html.escape(name)}'>Delete</a>"
+        "</p>"
+    )
     template = (TEMPLATE_DIR / "details.html").read_text(encoding="utf-8")
     body = Template(template).safe_substitute(
-        title=html.escape(entry.summary),
+        title=html.escape(entry.summary) + (" (ignored)" if entry.ignored else ""),
         occurrences=entry.occurrences,
         last_seen=html.escape(entry.last_seen),
         incident=incident_html,
         analysis=analysis_html,
-        name=html.escape(name),
+        actions=actions,
     )
     return body.encode("utf-8")
 
@@ -248,10 +313,31 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
                 self.send_header("Location", "/")
                 self.end_headers()
                 return
+            if path.startswith("/ignore/"):
+                name = path.split("/", 2)[2]
+                ignore_problem(directory, name)
+                self.send_response(303)
+                self.send_header("Location", f"/details/{name}")
+                self.end_headers()
+                return
+            if path.startswith("/unignore/"):
+                name = path.split("/", 2)[2]
+                unignore_problem(directory, name)
+                self.send_response(303)
+                self.send_header("Location", f"/details/{name}")
+                self.end_headers()
+                return
+            if path.startswith("/reanalyze/"):
+                name = path.split("/", 2)[2]
+                reanalyze_problem(directory, name)
+                self.send_response(303)
+                self.send_header("Location", f"/details/{name}")
+                self.end_headers()
+                return
             if path == "" or path == "/":
                 problems = _load_problems(directory)
                 entries = [
-                    (p.summary, p.occurrences, p.last_seen, key)
+                    (p.summary, p.occurrences, p.last_seen, key, p.ignored)
                     for key, p in problems.items()
                 ]
                 entries.sort(key=lambda x: x[1], reverse=True)
@@ -313,6 +399,9 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
 __all__ = [
     "list_problems",
     "delete_problem",
+    "ignore_problem",
+    "unignore_problem",
+    "reanalyze_problem",
     "render_index",
     "render_details",
     "start_http_server",

--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -7,6 +7,8 @@ body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121
 h1{margin-top:0;font-size:20px;}
 a{color:#03a9f4;text-decoration:none;}
 pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-break:break-word;}
+.button{display:inline-block;padding:8px 16px;margin-right:8px;border-radius:8px;background:#03a9f4;color:#fff;text-decoration:none;}
+.button.danger{background:#f44336;}
 </style>
 </head><body>
 <div class='card'>
@@ -16,5 +18,5 @@ pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-b
 $incident
 <h2>Analysis</h2>
 $analysis
-<p><a href="../">Back</a> | <a href="../delete/$name">Delete</a></p>
+$actions
 </div></body></html>

--- a/addons/ha-llm-ops/agent/templates/index.html
+++ b/addons/ha-llm-ops/agent/templates/index.html
@@ -12,6 +12,7 @@ body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121
 .name{flex:1;}
 .occurrences{color:#bbb;font-size:0.9em;margin-right:16px;}
 .timestamp{color:#bbb;font-size:0.9em;margin-right:16px;}
+.ignored{color:#f44336;font-size:0.8em;margin-left:8px;}
 </style>
 </head><body>
 <div class='card'>

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.55
+version: 0.0.56
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -109,3 +109,47 @@ def test_http_server(tmp_path: Path) -> None:
         assert not path.exists()
     finally:
         server.shutdown()
+
+
+def test_ignore_and_reanalyze(tmp_path: Path, monkeypatch) -> None:
+    rec1 = _record("2024-01-01T00:00:00Z", 1, _sample_result(), {"msg": "foo"})
+    path = tmp_path / "problems_1.jsonl"
+    path.write_text(f"{rec1}\n", encoding="utf-8")
+
+    class DummyLLM:
+        def generate(self, prompt: str, *, timeout: float) -> str:  # noqa: D401
+            data = _sample_result().copy()
+            data["summary"] = "reanalyzed"
+            return json.dumps(data)
+
+    monkeypatch.setattr(devux, "create_llm", lambda: DummyLLM())
+
+    server = devux.start_http_server(tmp_path, port=0)
+    try:
+        time.sleep(0.1)
+        port = server.server_address[1]
+        base = f"http://127.0.0.1:{port}"
+
+        resp = requests.get(base + "/", timeout=5)
+        match = re.search(r"details/(\w+)", resp.text)
+        assert match is not None
+        key = match.group(1)
+
+        resp = requests.get(f"{base}/reanalyze/nope", allow_redirects=False, timeout=5)
+        assert resp.status_code == 303
+
+        resp = requests.get(f"{base}/ignore/{key}", allow_redirects=False, timeout=5)
+        assert resp.status_code == 303
+        assert (tmp_path / f"{key}.ignored").exists()
+
+        resp = requests.get(f"{base}/unignore/{key}", allow_redirects=False, timeout=5)
+        assert resp.status_code == 303
+        assert not (tmp_path / f"{key}.ignored").exists()
+
+        resp = requests.get(f"{base}/reanalyze/{key}", allow_redirects=False, timeout=5)
+        assert resp.status_code == 303
+
+        resp = requests.get(f"{base}/details/{key}", timeout=5)
+        assert "reanalyzed" in resp.text
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- allow ignoring and unignoring problems
- trigger reanalysis from problem details
- show ignored flag in problem list and bump add-on version

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3472b718c8327b61173b13662af53