### PR TITLE
Ensure reanalysis updates existing problem

### DIFF
--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.56
+version: 0.0.57
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:


### PR DESCRIPTION
## Summary
- Replace reanalysis entries instead of creating new problems
- Redirect HTTP clients to updated problem key after reanalysis
- Bump ha-llm-ops add-on version

## Testing
- `pip install ".[dev]" && ruff check . --fix && ruff format . && mdformat . && mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a356dc381483279cbad46e3a27fcf1