### PR TITLE
refactor: remove agent symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 
 lint:
 >ruff check .
->mypy agent
+>mypy addons/ha-llm-ops/agent
 
 test:
->pytest --cov=agent --cov=addons/ha-llm-ops/agent --cov-report=term-missing --cov-fail-under=100
+>pytest --cov=agent --cov-report=term-missing --cov-fail-under=100
 
 format:
 >ruff format .

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.53
+version: 0.0.56
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/agent
+++ b/agent
@@ -1,1 +1,0 @@
-addons/ha-llm-ops/agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+src = ["addons/ha-llm-ops"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
@@ -37,16 +38,19 @@ select = ["E", "F", "I", "UP"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
+mypy_path = "addons/ha-llm-ops"
+files = ["addons/ha-llm-ops/agent"]
 
 [tool.pytest.ini_options]
 markers = [
     "integration: mark tests requiring Docker",
     "docker: tests that require a local Docker daemon",
 ]
-pythonpath = ["."]
-addopts = "--cov=agent --cov=addons/ha-llm-ops/agent --cov-report=term-missing --cov-fail-under=100"
+pythonpath = ["addons/ha-llm-ops"]
+addopts = "--cov=agent --cov-report=term-missing --cov-fail-under=100"
 
 [tool.setuptools]
+package-dir = {"" = "addons/ha-llm-ops"}
 packages = ["agent"]
 
 [tool.setuptools.package-data]

--- a/tests/test_executor_contracts.py
+++ b/tests/test_executor_contracts.py
@@ -19,7 +19,7 @@ def _normalize(schema: dict) -> dict:
 
 
 def test_schema_matches_export() -> None:
-    base = Path("agent/executor")
+    base = Path("addons/ha-llm-ops/agent/executor")
     cases = [
         (ActionProposal, "action_proposal_v1.json"),
         (ActionExecution, "action_execution_v1.json"),

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -34,11 +34,7 @@ def test_generate_uses_output_text(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_generate_falls_back_to_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    data = {
-        "output": [
-            {"type": "message", "content": [{"text": "fallback"}]}
-        ]
-    }
+    data = {"output": [{"type": "message", "content": [{"text": "fallback"}]}]}
 
     def fake_post(
         url: str,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import websockets
 
+import agent.problems as problems
 from agent.llm.mock import MockLLM
 from agent.problems import monitor
 
@@ -174,7 +175,7 @@ def test_monitor_extra_headers_and_break(
         assert "Authorization" in extra_headers
         return FakeConn()
 
-    monkeypatch.setattr("agent.problems.websockets.connect", fake_connect)
+    monkeypatch.setattr(problems.websockets, "connect", fake_connect)
 
     asyncio.run(
         monitor(

--- a/tests/test_rca_contract.py
+++ b/tests/test_rca_contract.py
@@ -9,7 +9,7 @@ from agent.contracts.rca import export_schema
 
 
 def test_schema_matches_export() -> None:
-    schema_path = Path("agent/contracts/rca_v1.json")
+    schema_path = Path("addons/ha-llm-ops/agent/contracts/rca_v1.json")
     exported = json.loads(schema_path.read_text())
     assert exported == RcaResult.model_json_schema()
 
@@ -44,4 +44,3 @@ def test_export_schema(tmp_path: Path) -> None:
     assert out.exists()
     # Ensure default path is also handled without writing
     export_schema()
-


### PR DESCRIPTION
## Summary
- drop root-level `agent` symlink and point tooling at addon path
- declare addon directory as ruff source and organize imports across tests
- sort imports in tests to satisfy linting
- organize monitor test imports and patch websockets via module reference

## Testing
- `pip install .[dev]`
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .` *(fails: Missing type parameters for generic type `dict` and other typing issues in tests)*
- `mypy --install-types --non-interactive addons/ha-llm-ops/agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2f815a8ac832794bdcd8b13230e85