### PR TITLE
Add trigger type to problem context and UI

### DIFF
--- a/addons/ha-llm-ops/agent/templates/details.html
+++ b/addons/ha-llm-ops/agent/templates/details.html
@@ -13,7 +13,7 @@ pre{background:#2b2b2b;padding:8px;border-radius:8px;white-space:pre-wrap;word-b
 </head><body>
 <div class='card'>
 <h1>$title</h1>
-<p>Occurrences: $occurrences<br>Last occurrence: $last_seen</p>
+<p>Occurrences: $occurrences<br>Last occurrence: $last_seen<br>Trigger: $trigger_type</p>
 <h2>Events</h2>
 $incident
 <h2>Analysis</h2>

--- a/addons/ha-llm-ops/agent/templates/index.html
+++ b/addons/ha-llm-ops/agent/templates/index.html
@@ -10,6 +10,7 @@ body{margin:0;padding:16px;font-family:'Roboto',sans-serif;background-color:#121
 .item:last-child{border-bottom:none;}
 .item a{color:#03a9f4;text-decoration:none;}
 .name{flex:1;}
+.trigger{color:#bbb;font-size:0.9em;margin-right:16px;}
 .occurrences{color:#bbb;font-size:0.9em;margin-right:16px;}
 .timestamp{color:#bbb;font-size:0.9em;margin-right:16px;}
 .ignored{color:#f44336;font-size:0.8em;margin-left:8px;}

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.57
+version: 0.0.58
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -27,11 +27,14 @@ def _record(
     occurrence: int,
     result: dict | None = None,
     extra: dict | None = None,
+    trigger: str | None = None,
 ) -> str:
     event: dict[str, object] = {"time": time_str}
     if extra:
         event.update(extra)
     data: dict[str, object] = {"event": event, "occurrence": occurrence}
+    if trigger is not None:
+        data["trigger_type"] = trigger
     if result is not None:
         data["result"] = result
     return json.dumps(data)
@@ -41,7 +44,7 @@ def test_list_and_delete(tmp_path: Path) -> None:
     rec1 = _record("2024-01-01T00:00:00Z", 1, _sample_result(), {"msg": "foo"})
     rec2 = json.dumps({"event": "bad", "occurrence": 1})
     rec3 = _record("2024-01-03T00:00:00Z", 1, extra={"msg": "bar"})
-    rec4 = _record("2024-01-04T00:00:00Z", 2, extra={"msg": "foo"})
+    rec4 = _record("2024-01-04T00:00:00Z", 2, extra={"msg": "foo"}, trigger="error_log")
     path = tmp_path / "problems_1.jsonl"
     path.write_text(f"{rec1}\n\n{rec2}\n{rec3}\n{rec4}\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- classify problems by trigger type (automation failure, error log, entity unavailable)
- include trigger type in problem logs and send to LLM analysis
- show trigger type in problem list and details
- cover trigger types with new tests and bump addon version

## Testing
- `pip install ".[dev]"`
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39340213c83278bc62bebd65505bf