### PR TITLE
Improve event batching

### DIFF
--- a/addons/ha-llm-ops/agent/problems.py
+++ b/addons/ha-llm-ops/agent/problems.py
@@ -178,7 +178,7 @@ async def monitor(
     llm: LLM | None = None,
     analysis_rate_seconds: float = 0.0,
     analysis_max_lines: int | None = None,
-    batch_seconds: float = 2.0,
+    batch_seconds: float = 1.0,
 ) -> None:
     """Observe events and analyze problems in a single loop."""
 
@@ -197,6 +197,7 @@ async def monitor(
         kwargs["additional_headers"] = headers
 
     last_analysis = 0.0
+    last_time_fired: datetime | None = None
 
     async def handle_batch(events: list[dict[str, Any]]) -> None:
         nonlocal last_analysis, processed, stop
@@ -217,14 +218,21 @@ async def monitor(
 
         etype = events[0].get("event_type")
         edata = events[0].get("data", {})
-        trigger = events[0].get("trigger_type")
+        triggers_set: set[str] = set()
+        for e in events:
+            t = e.get("trigger_type")
+            if isinstance(t, str):
+                triggers_set.add(t)
+        triggers = sorted(triggers_set)
+        trigger = ",".join(triggers) if triggers else None
         if matched is None:
             LOGGER.warning("New problem found: type=%s data=%s", etype, edata)
             record: dict[str, Any] = {
                 "event": event_ctx,
                 "occurrence": 1,
-                "trigger_type": trigger,
             }
+            if trigger:
+                record["trigger_type"] = trigger
             now = asyncio.get_event_loop().time()
             delay = last_analysis + analysis_rate_seconds - now
             if delay > 0:
@@ -263,8 +271,9 @@ async def monitor(
             record = {
                 "event": event_ctx,
                 "occurrence": matched["count"],
-                "trigger_type": trigger,
             }
+            if trigger:
+                record["trigger_type"] = trigger
 
         problem_logger.write(record)
         processed += 1
@@ -278,7 +287,7 @@ async def monitor(
             async with websockets.connect(url, **kwargs) as ws:
                 await _authenticate(ws, token)
                 await ws.send(json.dumps({"id": 1, "type": "subscribe_events"}))
-                await ws.send(json.dumps({"type": "supervisor/subscribe"}))
+                await ws.send(json.dumps({"id": 2, "type": "supervisor/subscribe"}))
                 async for message in ws:
                     if stop:
                         break
@@ -288,6 +297,11 @@ async def monitor(
                     event = data.get("event", {})
                     etype = event.get("event_type")
                     edata = event.get("data", {})
+                    time_str = event.get("time_fired")
+                    evt_time = None
+                    if isinstance(time_str, str):
+                        with contextlib.suppress(ValueError):
+                            evt_time = datetime.fromisoformat(time_str)
 
                     trigger_type: str | None = None
 
@@ -322,6 +336,12 @@ async def monitor(
 
                     if trigger_type is None:
                         continue
+
+                    if evt_time is not None and last_time_fired is not None:
+                        if (evt_time - last_time_fired).total_seconds() > batch_seconds:
+                            await batcher.flush()
+                    if evt_time is not None:
+                        last_time_fired = evt_time
 
                     event["trigger_type"] = trigger_type
                     batcher.add(event)

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.58
+version: 0.0.59
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_analysis_e2e.py
+++ b/tests/test_analysis_e2e.py
@@ -22,7 +22,8 @@ async def _serve(events: list[dict]) -> tuple[Any, str]:
         await ws.recv()  # auth
         await ws.send(json.dumps({"type": "auth_ok"}))
         await ws.recv()  # subscribe events
-        await ws.recv()  # supervisor subscribe
+        msg = json.loads(await ws.recv())  # supervisor subscribe
+        assert "id" in msg
         for evt in events:
             await ws.send(json.dumps(evt))
         await asyncio.sleep(0.1)

--- a/tests/test_monitor_logging.py
+++ b/tests/test_monitor_logging.py
@@ -21,7 +21,8 @@ async def _serve(events: list[dict]) -> tuple[Any, str]:
         await ws.recv()
         await ws.send(json.dumps({"type": "auth_ok"}))
         await ws.recv()
-        await ws.recv()
+        msg = json.loads(await ws.recv())
+        assert "id" in msg
         for evt in events:
             await ws.send(json.dumps(evt))
         await asyncio.sleep(0.1)


### PR DESCRIPTION
## Summary
- use event timestamps to break batches over 1 second apart
- include all trigger types when batching events
- fix supervisor event subscription and bump addon version

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a42e3f072c83278bd4ceebadf79827