### PR TITLE
fix: handle query strings in devux server

### DIFF
--- a/addons/ha-llm-ops/agent/devux.py
+++ b/addons/ha-llm-ops/agent/devux.py
@@ -13,6 +13,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from string import Template
 from typing import Any
+from urllib.parse import urlsplit
 
 from .llm import LLM, create_llm
 from .parse import parse_result
@@ -335,7 +336,7 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: D401 - HTTP handler
-            path = self.path.rstrip("/")
+            path = urlsplit(self.path).path.rstrip("/")
             if path.startswith("/delete/"):
                 name = path.split("/", 2)[2]
                 delete_problem(directory, name)
@@ -415,8 +416,9 @@ def start_http_server(directory: Path, *, port: int = 8000) -> ThreadingHTTPServ
             self.wfile.write(body)
 
         def do_DELETE(self) -> None:  # noqa: D401 - HTTP handler
-            if self.path.startswith("/delete/"):
-                name = self.path.split("/", 2)[2]
+            path = urlsplit(self.path).path
+            if path.startswith("/delete/"):
+                name = path.split("/", 2)[2]
                 delete_problem(directory, name)
                 self.send_response(200)
                 self.end_headers()

--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.59
+version: 0.0.60
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_devux.py
+++ b/tests/test_devux.py
@@ -89,6 +89,9 @@ def test_http_server(tmp_path: Path) -> None:
         base = f"http://127.0.0.1:{port}"
         resp = requests.get(base + "/", timeout=5)
         assert "Problem summary" in resp.text
+        resp_q = requests.get(base + "/?foo=1", timeout=5)
+        assert resp_q.status_code == 200
+        assert "Problem summary" in resp_q.text
         match = re.search(r"details/(\w+)", resp.text)
         assert match is not None
         key = match.group(1)


### PR DESCRIPTION
## Summary
- ensure devux HTTP server ignores query strings so addon UI renders
- add regression test for requests with query parameters
- bump addon version to 0.0.60

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mdformat .`
- `mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4799688288327b3fad4f48b87c32b