### PR TITLE
Fix event batching and supervisor subscription

### DIFF
--- a/addons/ha-llm-ops/config.yaml
+++ b/addons/ha-llm-ops/config.yaml
@@ -1,5 +1,5 @@
 name: HA LLM Ops
-version: 0.0.58
+version: 0.0.59
 slug: ha_llm_ops
 description: LLM-powered add-on that analyzes Home Assistant problems and suggests safe fixes.
 arch:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -121,6 +121,7 @@ def test_monitor_batches_events(tmp_path: Path) -> None:
     files = sorted(tmp_path.glob("problems_*.jsonl"))
     lines = [json.loads(line) for line in files[0].read_text().splitlines()]
     assert len(lines[0]["event"]["events"]) == 2
+    assert lines[0]["trigger_type"] == "automation_failure,entity_unavailable"
 
 
 def test_monitor_records_trigger_types(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- avoid grouping events with large time gaps and track trigger types across batches
- subscribe to supervisor events with an id to enable add-on error logs
- bump add-on version to 0.0.59

## Testing
- `ruff check . --fix && ruff format . && mdformat . && mypy --install-types --non-interactive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4877daaf083278ae9b0021f2486e1